### PR TITLE
Modernize Ediff Support

### DIFF
--- a/cc-context-menu.el
+++ b/cc-context-menu.el
@@ -117,7 +117,7 @@ containing a match for regex"))
                                 "Show the status of the current Git repository \
 in a buffer")
       (cc/add-context-menu-item menu
-                                cc/ediff-revision
+                                cc/ediff-revision-from-menu
                                 "Ediff revision…"
                                 "Ediff this file with revision")
       (cc/add-context-menu-item menu

--- a/cc-ediff-mode.el
+++ b/cc-ediff-mode.el
@@ -1,0 +1,158 @@
+;;; cc-ediff-mode.el --- Ediff configuration for Charles Choi
+;; ediff-mode
+
+;;; Commentary:
+;; 
+
+(require 'ediff)
+;;; Code:
+
+(defvar ediff-buffer-A)
+(defvar ediff-buffer-B)
+(defvar ediff-buffer-C)
+(defvar ediff-merge-job)
+(defvar ediff-ancestor-buffer)
+
+;; CC: I set my Ediff variables in `custom-set-variables'
+;; Use your own preference.
+;; '(ediff-keep-variants nil)
+;; '(ediff-split-window-function 'split-window-horizontally)
+;; '(ediff-window-setup-function 'ediff-setup-windows-plain)
+
+(defvar cc/ediff-revision-session-p nil
+  "If t then `cc/ediff-revision-actual' has been called.
+This state variable is used to insert added behavior to the overridden
+function `ediff-janitor'.")
+
+(defun cc/ediff-revision-from-menu (e)
+  "Invoke `ediff-revision' on E with variable `buffer-file-name'."
+  (interactive "e")
+  (cc/ediff-revision))
+
+(defun cc/ediff-revision ()
+  "Run Ediff on the current `buffer-file-name' provided that it is `vc-registered'.
+This function handles the interactive concerns found in `ediff-revision'.
+This function will also test if a diff should apply to the current buffer."
+  (interactive)
+  (when (and (bound-and-true-p buffer-file-name)
+             (vc-registered (buffer-file-name)))
+    (if (and (buffer-modified-p)
+	     (y-or-n-p (format "Buffer %s is modified.  Save buffer? "
+                               (buffer-name))))
+      (save-buffer (current-buffer)))
+    (message buffer-file-name)
+    (cc/ediff-revision-actual))
+
+  (cond ((not (bound-and-true-p buffer-file-name))
+         (message (concat (buffer-name) " is not a file that can be diffed.")))
+        ((not (vc-registered buffer-file-name))
+         (message (concat buffer-file-name " is not under version control.")))))
+
+(defun cc/ediff-revision-actual ()
+  "Invoke Ediff logic to diff the modified repo file to its counterpart in the
+current branch.
+This function handles the actual diff behavior called by `ediff-revision'."
+  (let ((rev1 "")
+        (rev2 ""))
+    (setq cc/ediff-revision-session-p t)
+    (ediff-load-version-control)
+    (funcall
+     (intern (format "ediff-%S-internal" ediff-version-control-package))
+     rev1 rev2 nil)))
+
+(defun ediff-janitor (ask keep-variants)
+  "Kill buffers A, B, and, possibly, C, if these buffers aren't modified.
+In merge jobs, buffer C is not deleted here, but rather according to
+`ediff-quit-merge-hook'.
+ASK non-nil means ask the user whether to keep each unmodified buffer, unless
+KEEP-VARIANTS is non-nil, in which case buffers are never killed.
+A side effect of cleaning up may be that you should be careful when comparing
+the same buffer in two separate Ediff sessions: quitting one of them might
+delete this buffer in another session as well.
+
+CC MODIFICATION: This method overrides the original Ediff function."
+  (let ((ask (if (and (boundp 'cc/ediff-revision-session-p)
+                      cc/ediff-revision-session-p)
+                 nil
+               ask)))
+    (ediff-dispose-of-variant-according-to-user
+     ediff-buffer-A 'A ask keep-variants)
+    ;; !!!: CC Note: Test global state variable `cc/ediff-revision-session-p' to
+    ;; determine if the modified repo file should be kept.
+    ;; Guarding in place to hopefully avoid side-effects when `ediff-janitor' is
+    ;; called from other Ediff functions. Informal testing has not revealed any
+    ;; side-effects but YOLO.
+    (if (and (boundp 'cc/ediff-revision-session-p)
+             cc/ediff-revision-session-p)
+        (ediff-dispose-of-variant-according-to-user
+         ;; CC Note: keep-variants argument is hard-coded to t to keep
+         ;; buffer holding modified repo file around.
+         ediff-buffer-B 'B t t)
+      (ediff-dispose-of-variant-according-to-user
+       ediff-buffer-B 'B ask keep-variants))
+    (if ediff-merge-job  ; don't del buf C if merging--del ancestor buf instead
+        (ediff-dispose-of-variant-according-to-user
+         ediff-ancestor-buffer 'Ancestor ask keep-variants)
+      (ediff-dispose-of-variant-according-to-user
+       ediff-buffer-C 'C ask keep-variants))
+    ;; CC Note: Reset global state variable `cc/ediff-revision-session-p'.
+    (if (and (boundp 'cc/ediff-revision-session-p)
+             cc/ediff-revision-session-p)
+        (setq cc/ediff-revision-session-p nil))))
+
+(defun ediff-quit (reverse-default-keep-variants)
+  "Finish an Ediff session and exit Ediff.
+Unselects the selected difference, if any, restores the read-only and modified
+flags of the compared file buffers, kills Ediff buffers for this session
+\(but not buffers A, B, C).
+
+If `ediff-keep-variants' is nil, the user will be asked whether the buffers
+containing the variants should be removed (if they haven't been modified).
+If it is t, they will be preserved unconditionally.
+
+With prefix argument REVERSE-DEFAULT-KEEP-VARIANTS, temporarily
+reverse the meaning of this variable.
+
+CC MODIFICATION: This method overrides the original Ediff function."
+  (interactive "P")
+  (ediff-barf-if-not-control-buffer)
+  (let ((ctl-buf (current-buffer))
+	(ctl-frm (selected-frame))
+	(minibuffer-auto-raise t))
+    (if (y-or-n-p (format "Quit this Ediff session%s? "
+			  (if (ediff-buffer-live-p ediff-meta-buffer)
+			      " & show containing session group" "")))
+	(progn
+	  (message "")
+	  (setq this-command 'ediff-quit) ; bug#38219
+	  (set-buffer ctl-buf)
+	  (ediff-really-quit reverse-default-keep-variants))
+      (select-frame ctl-frm)
+      (raise-frame ctl-frm)
+      (message ""))
+    ;; !!!: CC Note: Unfortunately `ediff-quit-hook' is called too soon to make
+    ;; restoring the window configuration useful. 
+    ;; Explicitly calling `cc/restore-window-configuration-for-ediff' here
+    ;; will avoid breaking the existing Ediff logic to cleanup a number of
+    ;; ancillary buffers related to the diff.
+    ;; Informally tested to see if there are any side-effects and have found
+    ;; none so far. YOLO though.
+    (cc/restore-window-configuration-for-ediff)))
+
+(defun cc/stash-window-configuration-for-ediff ()
+  "Store window configuration to register 🧊.
+Use of emoji is to avoid potential use of keyboard character to reference
+the register."
+  (window-configuration-to-register ?🧊))
+
+(defun cc/restore-window-configuration-for-ediff ()
+  "Restore window configuration from register 🧊.
+Use of emoji is to avoid potential use of keyboard character to reference
+the register."
+  (jump-to-register ?🧊))
+
+(add-hook 'ediff-before-setup-hook #'cc/stash-window-configuration-for-ediff)
+
+(provide 'cc-ediff-mode)
+
+;;; cc-ediff-mode.el ends here

--- a/cc-info-mode.el
+++ b/cc-info-mode.el
@@ -1,6 +1,10 @@
+;; Info-mode
 
-(add-hook 'Info-mode-hook (lambda ()
-                            (define-key Info-mode-map (kbd "M-[") 'Info-history-back)
-                            (define-key Info-mode-map (kbd "M-]") 'Info-history-forward)
-                            (define-key Info-mode-map (kbd "<mouse-5>") 'Info-history-forward)
-                            (define-key Info-mode-map (kbd "<mouse-4>") 'Info-history-back)))
+(add-hook 'Info-mode-hook
+          (lambda ()
+            (define-key Info-mode-map (kbd "M-[") 'Info-history-back)
+            (define-key Info-mode-map (kbd "M-]") 'Info-history-forward)
+            (define-key Info-mode-map (kbd "<mouse-5>") 'Info-history-forward)
+            (define-key Info-mode-map (kbd "<mouse-4>") 'Info-history-back)))
+
+(provide 'cc-info-mode)

--- a/ccinit.el
+++ b/ccinit.el
@@ -43,6 +43,8 @@
 (require 'cc-google-translate)
 (require 'cc-appearance)
 (require 'cc-repeat-mode)
+(require 'cc-info-mode)
+(require 'cc-ediff-mode)
 (require 'cc-context-menu)
 (require 'flyspell)
 (require 'cc-global-keybindings)

--- a/cclisp.el
+++ b/cclisp.el
@@ -235,68 +235,6 @@ ISO 8601."
          "textutil -stdin -format html -convert rtf -stdout | pbcopy"))
       (kill-buffer buf))))
 
-(defvar cc/ediff-revision-session-p nil
-  "If t then cc/ediff-revision has been called.")
-
-(defun cc/ediff-revision (e)
-  "Invoke `ediff-revision' on E with variable `buffer-file-name'."
-  (interactive "e")
-  (setq cc/ediff-revision-session-p t)
-
-  (if (and (buffer-modified-p)
-	   (y-or-n-p (format "Buffer %s is modified.  Save buffer? "
-                             (buffer-name))))
-      (save-buffer (current-buffer)))
-  (let ((rev1 "")
-        (rev2 ""))
-    (ediff-load-version-control)
-    (funcall
-     (intern (format "ediff-%S-internal" ediff-version-control-package))
-     rev1 rev2 nil)))
-
-(defun ediff-janitor (ask keep-variants)
-  "Kill buffers A, B, and, possibly, C, if these buffers aren't modified.
-In merge jobs, buffer C is not deleted here, but rather according to
-`ediff-quit-merge-hook'.
-ASK non-nil means ask the user whether to keep each unmodified buffer, unless
-KEEP-VARIANTS is non-nil, in which case buffers are never killed.
-A side effect of cleaning up may be that you should be careful when comparing
-the same buffer in two separate Ediff sessions: quitting one of them might
-delete this buffer in another session as well."
-  (let ((ask (if (and (boundp 'cc/ediff-revision-session-p)
-                      cc/ediff-revision-session-p)
-                 nil
-               ask)))
-    (ediff-dispose-of-variant-according-to-user
-     ediff-buffer-A 'A ask keep-variants)
-
-    (if (and (boundp 'cc/ediff-revision-session-p)
-             cc/ediff-revision-session-p)
-        (ediff-dispose-of-variant-according-to-user
-         ediff-buffer-B 'B t t)
-      (ediff-dispose-of-variant-according-to-user
-       ediff-buffer-B 'B ask keep-variants))
-    (if ediff-merge-job  ; don't del buf C if merging--del ancestor buf instead
-        (ediff-dispose-of-variant-according-to-user
-         ediff-ancestor-buffer 'Ancestor ask keep-variants)
-      (ediff-dispose-of-variant-according-to-user
-       ediff-buffer-C 'C ask keep-variants))
-    (if (boundp 'cc/ediff-revision-session-p)
-        (setq cc/ediff-revision-session-p nil))))
-
-(defvar my-ediff-last-windows nil)
-
-(defun my-store-pre-ediff-winconfig ()
-  "Store `current-window-configuration' in variable `my-ediff-last-windows'."
-  (setq my-ediff-last-windows (current-window-configuration)))
-
-(defun my-restore-pre-ediff-winconfig ()
-  "Restore window configuration to stored value in `my-ediff-last-windows'."
-  (set-window-configuration my-ediff-last-windows))
-
-(add-hook 'ediff-before-setup-hook #'my-store-pre-ediff-winconfig)
-(add-hook 'ediff-quit-hook #'my-restore-pre-ediff-winconfig)
-
 
 ;; See `trash-directory' as it requires defining `system-move-file-to-trash'.
 (defun system-move-file-to-trash (file)


### PR DESCRIPTION
This fixes a number of issues with calling Ediff.

- Fix logic to restore window configuration.
- Fix logic to enable streamlined workflow for diffing a modified repo file.
- Copied over Ediff variables that I set in custom-set-variables.