### PR TITLE
Make Babel ingest a manual step in the Tools menu

### DIFF
--- a/cc-menu-reconfig.el
+++ b/cc-menu-reconfig.el
@@ -175,6 +175,17 @@ in a buffer"]
 various time zones."]
                     "Programmable Calculator")
 
+(easy-menu-add-item global-map '(menu-bar tools)
+                    ["Babel Ingest - Org Table To SQL"
+                     (org-babel-lob-ingest "~/org/babel/cc-org-table-to-sql.org")
+                     :help "Ingest code block to convert Org Table to SQLite."]
+                    "Games")
+
+(keymap-set-after (lookup-key global-map [menu-bar tools])
+  "<separator-babel>"
+  '(menu-item "--")
+  'Babel\ Ingest\ -\ Org\ Table\ To\ SQL)
+
 ;; Streamlined Bookmarks Menu
 (easy-menu-define cc/bookmarks-menu nil
   "Keymap for CC Bookmarks Menu"

--- a/cc-org-mode.el
+++ b/cc-org-mode.el
@@ -96,7 +96,6 @@
                            (define-key org-mode-map (kbd "C-<down>") 'org-next-visible-heading)
                            (define-key org-mode-map (kbd "M-v") 'org-previous-visible-heading)
                            (define-key org-mode-map (kbd "C-v") 'org-next-visible-heading)
-                           (org-babel-lob-ingest "~/org/babel/cc-org-table-to-sql.org")
                            (add-to-list (make-local-variable 'company-backends)
                                         'company-org-block)))
 


### PR DESCRIPTION
Apparently auto-loading org-babel-lob-ingest will invoke it every time an Org file is opened. As I only need this behavior whenever I want to run SQL on an Org table, this will need to be manually done via the Tools menu in the main menu.