### PR TITLE
Refactor input logic for Apple Map Search.

### DIFF
--- a/cc-org-mode.el
+++ b/cc-org-mode.el
@@ -1,4 +1,5 @@
 ;; org-mode
+(require 'org)
 
 (global-set-key "\C-cl" 'org-store-link)
 (global-set-key "\C-ca" 'org-agenda)


### PR DESCRIPTION
- Renamed cc/search-apple-maps to cc/apple-maps-search
- Support in cc/apple-maps-search input via
  - active region or
  - thing at point
- Update Transient to support cc/apple-maps-search