### PR TITLE
Added support for save mode hooks

### DIFF
--- a/cc-markdown-mode.el
+++ b/cc-markdown-mode.el
@@ -1,4 +1,11 @@
+;;; cc-markdown-mode.el --- Markdown customizations
 ;; markdown-mode
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'cc-save-hooks)
 (defvar markdown-mode-map)
 
 (autoload 'markdown-mode "markdown-mode"
@@ -6,13 +13,19 @@
 
 (add-hook 'markdown-mode-hook 'variable-pitch-mode)
 ;;(add-hook 'markdown-mode-hook 'markdown-toggle-markup-hiding)
-(add-hook 'markdown-mode-hook (lambda ()
-                                (turn-on-orgtbl)
-                                (define-key markdown-mode-map (kbd "C-<up>") 'markdown-backward-same-level)
-                                (define-key markdown-mode-map (kbd "C-<down>") 'markdown-forward-same-level)
-                                (define-key markdown-mode-map (kbd "M-v") 'markdown-outline-previous)
-                                (define-key markdown-mode-map (kbd "C-v") 'markdown-outline-next)
-                                (define-key markdown-mode-map (kbd "M-<f6>") 'markdown-toggle-inline-images)
-                                (define-key markdown-mode-map [f13] 'markdown-preview)))
+
+(add-hook
+ 'markdown-mode-hook
+ (lambda ()
+   (turn-on-orgtbl)
+   (define-key markdown-mode-map (kbd "C-<up>") 'markdown-backward-same-level)
+   (define-key markdown-mode-map (kbd "C-<down>") 'markdown-forward-same-level)
+   (define-key markdown-mode-map (kbd "M-v") 'markdown-outline-previous)
+   (define-key markdown-mode-map (kbd "C-v") 'markdown-outline-next)
+   (define-key markdown-mode-map (kbd "M-<f6>") 'markdown-toggle-inline-images)
+   (define-key markdown-mode-map [f13] 'markdown-preview)))
+
+(add-hook 'markdown-mode-hook #'cc/save-hook-delete-trailing-whitespace)
 
 (provide 'cc-markdown-mode)
+;;; cc-markdown-mode.el ends here

--- a/cc-org-mode.el
+++ b/cc-org-mode.el
@@ -7,6 +7,12 @@
 ;;; Code:
 (require 'org)
 (require 'doct)
+(require 'org-superstar)
+(require 'face-remap)
+(require 'cclisp)
+(require 'cc-save-hooks)
+(require 'company)
+(require 'hl-line)
 
 (global-set-key "\C-cl" 'org-store-link)
 (global-set-key "\C-ca" 'org-agenda)
@@ -186,26 +192,29 @@ This function is intended to be passed into `doct' via the :function property."
 (add-hook 'org-mode-hook 'variable-pitch-mode)
 (add-hook 'org-mode-hook 'org-indent-mode)
 (add-hook 'org-mode-hook 'org-clock-persistence-insinuate)
+(add-hook 'org-mode-hook #'cc/save-hook-delete-trailing-whitespace)
 
-(add-hook 'org-mode-hook (lambda ()
-                           (define-key org-mode-map (kbd "M-<f8>") 'datestamp)
-                           ;; (define-key org-mode-map (kbd "<f9>") 'avy-goto-word-1)
-                           (define-key org-mode-map (kbd "M-<f6>") 'org-toggle-inline-images)
-                           (define-key org-mode-map (kbd "C-c t") 'cc/org-time-stamp-inactive)
-                           (define-key org-mode-map (kbd "<home>") 'org-beginning-of-line)
-                           (define-key org-mode-map (kbd "<end>") 'org-end-of-line)
-                           (define-key org-mode-map (kbd "A-<left>") 'org-backward-sentence)
-                           (define-key org-mode-map (kbd "A-<right>") 'org-forward-sentence)
-                           (define-key org-mode-map (kbd "A-M-<left>") 'org-backward-paragraph)
-                           (define-key org-mode-map (kbd "A-M-<right>") 'org-forward-paragraph)
-                           (define-key org-mode-map (kbd "C-<up>") 'org-previous-visible-heading)
-                           (define-key org-mode-map (kbd "C-<down>") 'org-next-visible-heading)
-                           (define-key org-mode-map (kbd "M-v") 'org-previous-visible-heading)
-                           (define-key org-mode-map (kbd "M-j") 'cc/journal-entry)
-                           (define-key org-mode-map (kbd "C-v") 'org-next-visible-heading)
-                           (define-key org-mode-map (kbd "C-/") 'org-emphasize)
-                           (add-to-list (make-local-variable 'company-backends)
-                                        'company-org-block)))
+(add-hook
+ 'org-mode-hook
+ (lambda ()
+   (define-key org-mode-map (kbd "M-<f8>") 'datestamp)
+   ;; (define-key org-mode-map (kbd "<f9>") 'avy-goto-word-1)
+   (define-key org-mode-map (kbd "M-<f6>") 'org-toggle-inline-images)
+   (define-key org-mode-map (kbd "C-c t") 'cc/org-time-stamp-inactive)
+   (define-key org-mode-map (kbd "<home>") 'org-beginning-of-line)
+   (define-key org-mode-map (kbd "<end>") 'org-end-of-line)
+   (define-key org-mode-map (kbd "A-<left>") 'org-backward-sentence)
+   (define-key org-mode-map (kbd "A-<right>") 'org-forward-sentence)
+   (define-key org-mode-map (kbd "A-M-<left>") 'org-backward-paragraph)
+   (define-key org-mode-map (kbd "A-M-<right>") 'org-forward-paragraph)
+   (define-key org-mode-map (kbd "C-<up>") 'org-previous-visible-heading)
+   (define-key org-mode-map (kbd "C-<down>") 'org-next-visible-heading)
+   (define-key org-mode-map (kbd "M-v") 'org-previous-visible-heading)
+   (define-key org-mode-map (kbd "M-j") 'cc/journal-entry)
+   (define-key org-mode-map (kbd "C-v") 'org-next-visible-heading)
+   (define-key org-mode-map (kbd "C-/") 'org-emphasize)
+   (add-to-list (make-local-variable 'company-backends)
+                'company-org-block)))
 
 (add-hook 'org-agenda-finalize-hook 'hl-line-mode)
 (add-hook 'org-agenda-finalize-hook
@@ -220,12 +229,13 @@ This function is intended to be passed into `doct' via the :function property."
   (org-agenda-goto-today)
   (search-forward " now "))
 
-(add-hook 'org-agenda-mode-hook
-          (lambda ()
-            (define-key org-agenda-mode-map (kbd "<f1>") 'org-save-all-org-buffers)
-            (define-key org-agenda-mode-map (kbd "M-p") 'org-agenda-previous-date-line)
-            (define-key org-agenda-mode-map (kbd "M-n") 'org-agenda-next-date-line)
-            (define-key org-agenda-mode-map (kbd ".") 'cc/org-agenda-goto-now)))
+(add-hook
+ 'org-agenda-mode-hook
+ (lambda ()
+   (define-key org-agenda-mode-map (kbd "<f1>") 'org-save-all-org-buffers)
+   (define-key org-agenda-mode-map (kbd "M-p") 'org-agenda-previous-date-line)
+   (define-key org-agenda-mode-map (kbd "M-n") 'org-agenda-next-date-line)
+   (define-key org-agenda-mode-map (kbd ".") 'cc/org-agenda-goto-now)))
 
 (org-babel-do-load-languages
  'org-babel-load-languages

--- a/cc-prog-mode.el
+++ b/cc-prog-mode.el
@@ -1,4 +1,17 @@
+;;; cc-prog-mode.el --- Programming Customizations
 ;; prog-mode
+
+;;; Commentary:
+;;
+(require 'prog-mode)
+(require 'company)
+(require 'cc-save-hooks)
+(require 'rainbow-mode)
+(require 'display-line-numbers)
+(require 'display-fill-column-indicator)
+(require 'hl-line)
+
+;;; Code:
 
 (add-hook 'prog-mode-hook 'display-line-numbers-mode)
 (add-hook 'prog-mode-hook 'electric-pair-mode)
@@ -7,12 +20,12 @@
 (add-hook 'prog-mode-hook 'rainbow-mode)
 (add-hook 'prog-mode-hook 'display-fill-column-indicator-mode)
 (add-hook 'prog-mode-hook 'hl-line-mode)
+(add-hook 'prog-mode-hook #'cc/save-hook-delete-trailing-whitespace)
 
 (define-key prog-mode-map [remap indent-for-tab-command]
   #'company-indent-or-complete-common)
 
-;;(define-key prog-mode-map (kbd "<home>") 'back-to-indentation)
-(define-key prog-mode-map (kbd "C-a") 'beginning-of-line-text)
+(define-key prog-mode-map (kbd "C-a") 'back-to-indentation)
 
 ;; GUD - mode preferences
 (setq gud-mode-hook
@@ -25,3 +38,4 @@
                                 (local-set-key (kbd "<f9>") 'compile)))
 
 (provide 'cc-prog-mode)
+;;; cc-prog-mode.el ends here

--- a/cc-save-hooks.el
+++ b/cc-save-hooks.el
@@ -1,0 +1,31 @@
+;;; cc-save-hooks.el --- CC Save Hooks               -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(defun cc/save-hook-delete-trailing-whitespace ()
+  (add-hook 'before-save-hook #'delete-trailing-whitespace nil t))
+
+(provide 'cc-save-hooks)
+;;; cc-save-hooks.el ends here


### PR DESCRIPTION
Invoke delete-trailing-whitespace upon saving for the following modes:

- Org
- Markdown
- Prog

This commit also includes assorted code cleanup.