### PR TITLE
Initial support for sorting a Dired buffer.

### DIFF
--- a/cc-dired-mode.el
+++ b/cc-dired-mode.el
@@ -1,5 +1,12 @@
+;;; cc-dired-mode.el --- Dired Customization
 ;; dired-mode
+
+;;; Commentary:
+;;
+
+;;; Code:
 (require 'dired)
+(require 'transient)
 (require 'cclisp)
 
 (with-eval-after-load 'dired
@@ -7,8 +14,8 @@
 (add-hook 'dired-mode-hook 'hl-line-mode)
 (add-hook 'dired-mode-hook 'context-menu-mode)
 
-
 (defun cc/dired-inspect-object ()
+  "WIP: inspect Dired object."
   (interactive)
   (if (dired-get-subdir)
       ;; nop
@@ -39,12 +46,140 @@
 ;; (add-hook 'dired-mode-hook (lambda ()
 ;;                              (define-key dired-mode-map (kbd "<mouse-1>") 'cc/dired-inspect-object)))
 
-(add-hook 'dired-mode-hook (lambda ()
-                             (define-key dired-mode-map (kbd "M-o") 'dired-omit-mode)
-                             (define-key dired-mode-map (kbd "C-o") 'cc/meta-search)
-                             (define-key dired-mode-map (kbd "E") 'wdired-change-to-wdired-mode)
-                             (setq-local mouse-1-click-follows-link 'double)
-                             ;;(define-key dired-mode-map (kbd "A-M-<mouse-2>") 'cc/dired-inspect-object)
-                             (define-key dired-mode-map (kbd "A-M-<mouse-1>") 'browse-url-of-dired-file)))
+(transient-define-prefix cc/dired-sort-by ()
+  "Transient menu to sort Dired buffer by different criteria.
+This function requires GNU ls from coreutils installed."
+  :value '("--human-readable"
+           "--group-directories-first"
+           "--time-style=long-iso")
+  [["Arguments"
+    ("-a" "all" "--all")
+    ("g" "group directories first" "--group-directories-first")
+    ("-r" "reverse" "--reverse")
+    ("-h" "human readable" "--human-readable")
+    ("t" "time style" "--time-style="
+     :choices ("full-iso" "long-iso" "iso" "locale"))]
+
+   ["Sort By"
+    ("n"
+     "Name"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :name
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("k"
+     "Kind"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :kind
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("l"
+     "Date Last Opened"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :date-last-opened
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("a"
+     "Date Added"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :date-added
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("m"
+     "Date Modified"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :date-modified
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("M"
+     "Date Metadata Changed"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :date-metadata-changed
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("v"
+     "Version"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :version
+                           (transient-args transient-current-command)))
+     :transient nil)
+    ("s"
+     "Size"
+     (lambda () (interactive)
+       (cc/--dired-sort-by :size
+                           (transient-args transient-current-command)))
+     :transient nil)]])
+
+(defun cc/--dired-sort-by (criteria &optional prefix-args)
+  "Sort current Dired buffer according to CRITERIA and PREFIX-ARGS.
+This function will invoke `dired-sort-other' with arguments provided by
+`cc/dired-sort-by-transient-menu'.
+
+CRITERIA is a keyword of which the following are supported:
+(:name :kind :date-last-opened :date-added :date-modified
+ :date-metadata-changed :version :size)
+
+PREFIX-ARGS is a list returned from the function
+(`transient-args' `transient-current-command')
+
+This function requires GNU ls from coreutils installed."
+  (let* (arg-list (list))
+    (push "-l" arg-list)
+    ;;(push "--group-directories-first" arg-list)
+    (if prefix-args
+        (nconc arg-list prefix-args))
+
+    (cond
+     ((eq criteria :name)
+      (message "Sorting by name"))
+
+     ((eq criteria :kind)
+      (message "Sorting by kind")
+      (push "--sort=extension" arg-list))
+
+     ((eq criteria :date-last-opened)
+      (message "Sorting by date last opened")
+      (push "--sort=time" arg-list)
+      (push "--time=access" arg-list))
+
+     ((eq criteria :date-added)
+      (message "Sorting by date added")
+      (push "--sort=time" arg-list)
+      (push "--time=creation" arg-list))
+
+     ((eq criteria :date-modified)
+      (message "Sorting by date modified")
+      (push "--sort=time" arg-list)
+      (push "--time=modification" arg-list))
+
+     ((eq criteria :date-metadata-changed)
+      (message "Sorting by date metadata changed")
+      (push "--sort=time" arg-list)
+      (push "--time=status" arg-list))
+
+     ((eq criteria :version)
+      (message "Sorting by version")
+      (push "--sort=version" arg-list))
+
+     ((eq criteria :size)
+      (message "Sorting by size")
+      (push "-S" arg-list))
+
+     (t
+      (message "Default sorting by name")))
+
+    (dired-sort-other (mapconcat 'identity arg-list " "))))
+
+(add-hook
+ 'dired-mode-hook
+ (lambda ()
+   (define-key dired-mode-map (kbd "M-o") 'dired-omit-mode)
+   (define-key dired-mode-map (kbd "C-o") 'cc/meta-search)
+   (define-key dired-mode-map (kbd "E") 'wdired-change-to-wdired-mode)
+   (define-key dired-mode-map (kbd "s") 'cc/dired-sort-by)
+   (setq-local mouse-1-click-follows-link 'double)
+   ;;(define-key dired-mode-map (kbd "A-M-<mouse-2>") 'cc/dired-inspect-object)
+   (define-key dired-mode-map (kbd "A-M-<mouse-1>") 'browse-url-of-dired-file)))
 
 (provide 'cc-dired-mode)
+;;; cc-dired-mode.el ends here

--- a/cc-menu-reconfig.el
+++ b/cc-menu-reconfig.el
@@ -9,6 +9,17 @@
 (require 'text-mode)
 (require 'vc)
 (require 'helm)
+(require 'dired)
+(require 'transpose-frame)
+(require 'cc-region-operations-menu)
+(require 'cc-edit-text-menu)
+
+(defun cc/dired-side-right (path)
+  "Side-by-side layout with Dired buffer on the right set to PATH."
+  (interactive "DDirectory: ")
+  (delete-other-windows)
+  (dired-other-window path)
+  (transpose-frame))
 
 (easy-menu-add-item (lookup-key global-map [menu-bar file]) nil
                     ["Swap Windows"
@@ -164,10 +175,17 @@ in a buffer"]
                     "Calendar")
 
 (easy-menu-add-item global-map '(menu-bar tools)
+                    ["Dired on Right Side"
+                     cc/dired-side-right
+                     :help "Side-by-side layout with Dired buffer on the right set to PATH."]
+                    "Calendar")
+
+(easy-menu-add-item global-map '(menu-bar tools)
                     ["RE-Builder"
                      re-builder
                      :help "Construct a regexp interactively."]
                     "Calendar")
+
 
 (keymap-set-after (lookup-key global-map [menu-bar tools])
   "<separator-re>"
@@ -201,7 +219,7 @@ various time zones."]
     "---"
     ["Add Bookmark…" bookmark-set-no-overwrite
      :help "Set a bookmark named NAME at the current location."]
-    "---" 
+    "---"
     ["Jump to Bookmark…" bookmark-jump
      :help "Jump to bookmark"]))
 

--- a/custom.el
+++ b/custom.el
@@ -218,7 +218,8 @@
  '(dired-auto-revert-buffer t)
  '(dired-dwim-target 'dired-dwim-target-next)
  '(dired-guess-shell-alist-user '(("" "open")))
- '(dired-listing-switches "-alh --time-style=long-iso --sort=version")
+ '(dired-listing-switches
+   "-lh --group-directories-first --time-style=long-iso --sort=version")
  '(dired-mouse-drag-files t)
  '(dired-use-ls-dired 'unspecified)
  '(display-buffer-alist


### PR DESCRIPTION
- Use Transient menu for sort by UX
- Change default settings to the following
  - human readable
  - group-directories-first
  - time-style is long-iso
  - omit hidden files (-a is not used)
  - added function cc/dired-side-right for MC/4DOS style behavior