### PR TITLE
Support Dired sorting via mouse and misc fixes

### DIFF
--- a/cc-context-menu.el
+++ b/cc-context-menu.el
@@ -1,5 +1,12 @@
+;;; cc-context-menu.el --- Context Menu Customization
 ;; context-menu addons
 
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'easymenu)
 (require 'cc-context-menu-macros)
 (require 'cc-transform-text-menu)
 (require 'cc-style-text-menu)
@@ -8,9 +15,10 @@
 (require 'cc-find-menu)
 (require 'cc-edit-text-menu)
 (require 'cc-wgrep-mode)
+(require 'cc-dired-mode)
 
 (defun cc/context-menu-addons (menu click)
-  "CC context menu additions"
+  "CC context menu additions."
   (save-excursion
     (mouse-set-point click)
 
@@ -23,7 +31,7 @@
                                   :help "Show Org agenda with all TODO tasks."])
 
     (cc/context-menu-item-separator menu buffer-navigation-separator)
-        
+
     (easy-menu-add-item menu nil ["List All Buffers"
                                   list-buffers
                                   :help "List all buffers"])
@@ -36,23 +44,23 @@
                                   :label (cc/context-menu-label "Narrow Region")
                                   :help "Restrict editing in this buffer \
 to the current region"]))
-            
-            
+
+
             ((and (not (buffer-narrowed-p)) (derived-mode-p 'org-mode))
-             (cc/context-menu-item-separator menu narrow-separator)             
+             (cc/context-menu-item-separator menu narrow-separator)
              (easy-menu-add-item menu nil
                                  ["Narrow to subtree" org-narrow-to-subtree
                                   :help "Restrict editing in this buffer \
 to the current subtree"]))
-             
-            
+
+
             ((and (not (buffer-narrowed-p)) (derived-mode-p 'markdown-mode))
-             (cc/context-menu-item-separator menu narrow-separator)             
+             (cc/context-menu-item-separator menu narrow-separator)
              (easy-menu-add-item menu nil
                                  ["Narrow to subtree" markdown-narrow-to-subtree
                                   :help "Restrict editing in this buffer \
 to the current subtree"])))
-      
+
       (when (buffer-narrowed-p)
         (cc/context-menu-item-separator menu widen-separator)
         (easy-menu-add-item menu nil
@@ -60,8 +68,8 @@ to the current subtree"])))
                              :help "Remove narrowing restrictions \
 from current buffer"])))
 
-    (easy-menu-add-item menu nil "--")      
-    
+    (easy-menu-add-item menu nil "--")
+
     (cc/context-menu-item-separator menu capture-flow-separator)
     (easy-menu-add-item menu nil
                         ["New Workflow…"
@@ -80,9 +88,10 @@ from current buffer"])))
                         ["Open in Dired"
                          dired-jump-other-window
                          :visible (and (buffer-file-name) (not (derived-mode-p 'dired-mode)))
-                         :help "Open file in Dired"])    
-    
+                         :help "Open file in Dired"])
+
     (when (derived-mode-p 'dired-mode)
+      (easy-menu-add-item menu nil cc/dired-sort-menu)
       (easy-menu-add-item menu nil
                           ["Duplicate"
                            cc/dired-duplicate-file
@@ -96,9 +105,9 @@ from current buffer"])))
 
     (when (use-region-p)
       (cc/context-menu-item-separator menu dictionary-operations-separator)
-      (easy-menu-add-item menu nil ["Look Up" 
+      (easy-menu-add-item menu nil ["Look Up"
                                     osx-dictionary-search-word-at-point
-                                    :label (cc/context-menu-last-word-in-region "Look Up")                                    
+                                    :label (cc/context-menu-last-word-in-region "Look Up")
                                     :help "Look up selected region in macOS dictionary"]))
 
     (cc/context-menu-item-separator menu find-operations-separator)
@@ -114,10 +123,10 @@ a match for selected word"])
       (easy-menu-add-item menu nil
                           ["Find in buffer (occur)"
                            occur
-                           :visible (not buffer-read-only)                           
+                           :visible (not buffer-read-only)
                            :help "Show all lines in the current buffer \
 containing a match for regex"]))
-    
+
     (easy-menu-add-item menu nil cc/find-menu)
 
     (keymap-set-after menu
@@ -145,7 +154,7 @@ in a buffer"]))
                                   :help "Show log for the blob or file visited in \
 the current buffer"])
 
-    
+
     (when (use-region-p)
       (cc/context-menu-item-separator menu transform-text-separator)
       (easy-menu-add-item menu nil cc/transform-text-menu)
@@ -193,7 +202,7 @@ temporarily visible (Visible mode)"])
                           ["Toggle Reveal Markup"
                            markdown-toggle-markup-hiding
                            :help "Toggle the display or hiding of markup"])))
-     
+
     (when (org-at-table-p)
       (cc/context-menu-item-separator menu org-table-separator)
       (easy-menu-add-item menu nil
@@ -229,17 +238,17 @@ temporarily visible (Visible mode)"])
           (easy-menu-add-item menu nil ["Count Words in Region"
                                         count-words
                                         :help "Count words in region"])
-    
+
         (easy-menu-add-item menu nil ["Count Words in Buffer"
                                       count-words
                                       :help "Count words in buffer"])))
 
-    
+
     (easy-menu-add-item menu nil cc/transpose-menu)
     (easy-menu-add-item menu nil cc/move-text-menu)
     (easy-menu-add-item menu nil cc/delete-space-menu)
     (easy-menu-add-item menu nil cc/wgrep-menu)
-    
+
     menu))
 
 (defun cc/kill-org-table-reference (e)
@@ -251,3 +260,4 @@ temporarily visible (Visible mode)"])
 (add-hook 'context-menu-functions #'cc/context-menu-addons)
 
 (provide 'cc-context-menu)
+;;; cc-context-menu.el ends here

--- a/cc-dired-mode.el
+++ b/cc-dired-mode.el
@@ -1,4 +1,4 @@
-;;; cc-dired-mode.el --- Dired Customization
+;;; cc-dired-mode.el --- Dired Customization -*- lexical-binding: t -*-
 ;; dired-mode
 
 ;;; Commentary:
@@ -8,6 +8,8 @@
 (require 'dired)
 (require 'transient)
 (require 'cclisp)
+(require 'helm)
+(require 'easymenu)
 
 (with-eval-after-load 'dired
   (require 'dired-x))
@@ -123,12 +125,12 @@ PREFIX-ARGS is a list returned from the function
 (`transient-args' `transient-current-command')
 
 This function requires GNU ls from coreutils installed."
-  (let* (arg-list (list))
-    (push "-l" arg-list)
-    ;;(push "--group-directories-first" arg-list)
+  (let ((arg-list (list "-l")))
     (if prefix-args
-        (nconc arg-list prefix-args))
-
+        (nconc arg-list prefix-args)
+      (nconc arg-list (list "--group-directories-first"
+                            "--human-readable"
+                            "--time-style=long-iso")))
     (cond
      ((eq criteria :name)
       (message "Sorting by name"))
@@ -170,6 +172,26 @@ This function requires GNU ls from coreutils installed."
 
     (dired-sort-other (mapconcat 'identity arg-list " "))))
 
+(easy-menu-define cc/dired-sort-menu nil
+  "Keymap for Dired sort by submenu."
+  '("Sort By"
+    ["Name"
+     (lambda () (interactive) (cc/--dired-sort-by :name))]
+    ["Kind"
+     (lambda () (interactive) (cc/--dired-sort-by :kind))]
+    ["Date Last Opened"
+     (lambda () (interactive) (cc/--dired-sort-by :date-last-opened))]
+    ["Date Added"
+     (lambda () (interactive) (cc/--dired-sort-by :date-added))]
+    ["Date Modified"
+     (lambda () (interactive) (cc/--dired-sort-by :date-modified))]
+    ["Date Metadata Changed"
+     (lambda () (interactive) (cc/--dired-sort-by :date-metadata-changed))]
+    ["Version"
+     (lambda () (interactive) (cc/--dired-sort-by :version))]
+    ["Size"
+     (lambda () (interactive) (cc/--dired-sort-by :size))]))
+
 (add-hook
  'dired-mode-hook
  (lambda ()
@@ -177,6 +199,7 @@ This function requires GNU ls from coreutils installed."
    (define-key dired-mode-map (kbd "C-o") 'cc/meta-search)
    (define-key dired-mode-map (kbd "E") 'wdired-change-to-wdired-mode)
    (define-key dired-mode-map (kbd "s") 'cc/dired-sort-by)
+   (define-key dired-mode-map (kbd "j") 'helm-find-files)
    (setq-local mouse-1-click-follows-link 'double)
    ;;(define-key dired-mode-map (kbd "A-M-<mouse-2>") 'cc/dired-inspect-object)
    (define-key dired-mode-map (kbd "A-M-<mouse-1>") 'browse-url-of-dired-file)))

--- a/cc-doc-mode-ux.el
+++ b/cc-doc-mode-ux.el
@@ -10,6 +10,7 @@
 (require 'shortdoc)
 (require 'man)
 (require 'hl-line)
+(require 'simple)
 
 (defun cc/docview-backward-paragraph ()
   "Move point backward paragraph such that the first line is highlighted.
@@ -56,6 +57,7 @@ This function is intended to be used with `hl-line-mode'."
             (define-key Info-mode-map (kbd "<mouse-4>") 'Info-history-back)))
 
 (add-hook 'Info-mode-hook 'hl-line-mode)
+(add-hook 'Info-mode-hook 'visual-line-mode)
 
 ;; Help
 (add-hook 'help-mode-hook
@@ -79,6 +81,7 @@ This function is intended to be used with `hl-line-mode'."
             (define-key help-mode-map (kbd "<mouse-4>") 'help-go-back)))
 
 (add-hook 'help-mode-hook 'hl-line-mode)
+(add-hook 'help-mode-hook 'visual-line-mode)
 
 ;; Shortdoc
 (add-hook 'shortdoc-mode-hook
@@ -96,6 +99,7 @@ This function is intended to be used with `hl-line-mode'."
             (define-key shortdoc-mode-map (kbd "l") 'shortdoc-next-section)))
 
 (add-hook 'shortdoc-mode-hook 'hl-line-mode)
+(add-hook 'shortdoc-mode-hook 'visual-line-mode)
 
 ;; Man
 (add-hook 'Man-mode-hook
@@ -112,6 +116,7 @@ This function is intended to be used with `hl-line-mode'."
             (define-key Man-mode-map (kbd "K") 'Man-kill)))
 
 (add-hook 'Man-mode-hook 'hl-line-mode)
+(add-hook 'Man-mode-hook 'visual-line-mode)
 
 (provide 'cc-doc-mode-ux)
 

--- a/cc-global-keybindings.el
+++ b/cc-global-keybindings.el
@@ -49,8 +49,7 @@
 (global-set-key (kbd "C-c C-;") 'shell-command)
 (global-set-key (kbd "M-<f4>") 'helm-buffers-list)
 
-(global-set-key (kbd "<f13>") 'cc/ediff-revision)
-(global-set-key (kbd "M-<f13>") 'treemacs)
+(global-set-key (kbd "<f13>") 'treemacs)
 (global-set-key (kbd "<f14>") 'eshell) ;regular
 ;;(global-set-key (kbd "<f14>") 'save-buffer) ;logitech
 

--- a/cc-menu-reconfig.el
+++ b/cc-menu-reconfig.el
@@ -19,7 +19,8 @@
   (interactive "DDirectory: ")
   (delete-other-windows)
   (dired-other-window path)
-  (transpose-frame))
+  (transpose-frame)
+  (other-window 1))
 
 (easy-menu-add-item (lookup-key global-map [menu-bar file]) nil
                     ["Swap Windows"


### PR DESCRIPTION
- Define a proper mouse menu keymap for Dired sort by
- Bind j to helm-find-files in Dired
- Add visual-line-mode minor mode to all doc modes.
- Fix cc/dired-side-right to keep point in starting buffer.
- Run of checkdoc on cc-context-menu.el
- Fixed bug in let statement in cc/--dired-sort-by
- Change cc-dired-mode.el to lexical binding