### PR TITLE
Add sort escape logic for synthesized Dired buffers and other tuning

### DIFF
--- a/cc-dired-mode.el
+++ b/cc-dired-mode.el
@@ -34,6 +34,7 @@
   (require 'dired-x))
 (add-hook 'dired-mode-hook 'hl-line-mode)
 (add-hook 'dired-mode-hook 'context-menu-mode)
+(add-hook 'dired-mode-hook 'dired-async-mode)
 
 (defun cc/dired-image-info ()
   "Message image info in the minibuffer and push into kill-ring."

--- a/cc-dired-sort-by.el
+++ b/cc-dired-sort-by.el
@@ -143,6 +143,8 @@ Transient menu `cc/dired-sort-by'.
 This function requires GNU ls from coreutils installed.
 
 See the man page `ls(1)' for details."
+  (when dired-sort-inhibit
+    (error "Cannot sort this Dired buffer"))
   (let ((arg-list (list "-l")))
     (if prefix-args
         (nconc arg-list prefix-args)
@@ -191,7 +193,7 @@ See the man page `ls(1)' for details."
 (easy-menu-define cc/dired-sort-menu nil
   "Keymap for Dired sort by menu."
   '("Sort By"
-    :visible (derived-mode-p 'dired-mode)
+    :visible (and (derived-mode-p 'dired-mode) (not dired-sort-inhibit))
     ["Name"
      (lambda () (interactive) (cc/--dired-sort-by :name))
      :help "Sort by name"]

--- a/cc-eshell-mode.el
+++ b/cc-eshell-mode.el
@@ -22,14 +22,17 @@
 ;;; Commentary:
 ;;
 
-(require 'eshell)
 ;;; Code:
+(require 'eshell)
+(require 'company)
+(require 'hl-line)
+(require 'helm-eshell)
 
-(defvar eshell-mode-map)
-(defvar eshell-visual-options)
-(defvar eshell-visual-commands)
-(defvar eshell-visual-subcommands)
-(declare-function eshell/pwd "pwd" ())
+;; (defvar eshell-mode-map)
+;; (defvar eshell-visual-options)
+;; (defvar eshell-visual-commands)
+;; (defvar eshell-visual-subcommands)
+;; (declare-function eshell/pwd "pwd" ())
 
 (setq eshell-prompt-regexp "┗━━ \\$ "
       eshell-prompt-function
@@ -45,6 +48,7 @@
                 (if (= (user-uid) 0) "# " "$ "))))
 
 (add-hook 'eshell-mode-hook 'company-mode)
+(add-hook 'eshell-mode-hook 'hl-line-mode)
 (add-hook 'eshell-mode-hook (lambda ()
 			      (define-key eshell-mode-map (kbd "<tab>") 'company-complete)
 			      (define-key eshell-mode-map (kbd "C-r") 'helm-eshell-history)

--- a/cc-text-mode.el
+++ b/cc-text-mode.el
@@ -32,8 +32,6 @@
 (add-hook 'text-mode-hook (lambda ()
                             (setq-local line-spacing 0.1)))
 
-(define-key text-mode-map (kbd "<home>") 'beginning-of-visual-line)
-(define-key text-mode-map (kbd "<end>") 'end-of-visual-line)
 (define-key text-mode-map (kbd "A-<left>") 'backward-sentence)
 (define-key text-mode-map (kbd "A-<right>") 'forward-sentence)
 (define-key text-mode-map (kbd "A-M-<left>") 'backward-paragraph)

--- a/custom.el
+++ b/custom.el
@@ -226,7 +226,7 @@
  '(dired-use-ls-dired 'unspecified)
  '(display-buffer-alist
    '(("\\*eshell\\*" display-buffer-at-bottom
-      (window-height . 0.15))))
+      (window-height . 0.2))))
  '(display-time-day-and-date t)
  '(display-time-mode t)
  '(ebib-bibtex-dialect 'biblatex)


### PR DESCRIPTION
- Add hook for dired-async-mode
- Add logic to avoid synthesized Dired buffers when sorting
- Cleanup eshell customization
- Revert <home> and <end> to macOS behavior for text-mode
- Tune eshell buffer height