### PR TITLE
Refactor org-capture-templates

### DIFF
--- a/cclisp.el
+++ b/cclisp.el
@@ -82,7 +82,7 @@ A new frame will be created if `pop-up-frames' is t."
       (switch-to-buffer new-shell-name))))
 
 (defun journal()
-  "Alias to invoke `status-report' for Charles Choi."
+  "Redirection for `status-report' for Charles Choi."
   (interactive)
   (cond
    ((string= (system-name) "bingsu.local")

--- a/custom.el
+++ b/custom.el
@@ -431,24 +431,23 @@
  '(package-install-upgrade-built-in t)
  '(package-selected-packages
    '(async auto-complete autopair bind-key calfw calle24 casual-suite citar company
-           company-org-block company-restclient csv-mode diff-hl disk-usage doct
-           ebib edit-indirect editorconfig eglot eldoc elfeed erc
-           eshell-git-prompt expand-region faceup fireplace flycheck-package
-           flymake git-link gnuplot go-mode good-scroll google-this
-           google-translate graphviz-dot-mode helm helm-bibtex helm-pass
-           helm-swoop htmlize idlwave iedit js2-mode json-mode jsonian jsonrpc
-           kanban keycast ledger-mode magit markdown-mode math-symbol-lists
-           modus-themes neotree ob-restclient ob-swift ob-swiftui org
-           org-outline-numbering org-ql org-re-reveal org-ref org-superstar
-           orgtbl-aggregate osx-dictionary ox-gfm ox-gist ox-jira ox-slack
-           ox-trac package-lint paredit password-store password-store-menu
-           pbcopy pkg-info plantuml-mode project python python-mode rainbow-mode
-           restclient reveal-in-folder scpaste show-font
-           smart-mode-line-powerline-theme snow soap-client solarized-theme
-           spotlight sqlite-mode-extras sr-speedbar svg-clock swift-mode
-           symbol-overlay tj3-mode toc-org track-changes tramp transpose-frame
-           treemacs use-package verilog-mode visual-regexp
-           visual-regexp-steroids vtable webpaste wgrep which-key
+           company-org-block company-restclient csv-mode diff-hl disk-usage ebib
+           edit-indirect editorconfig eglot eldoc elfeed erc eshell-git-prompt
+           expand-region faceup fireplace flycheck-package flymake git-link
+           gnuplot go-mode good-scroll google-this google-translate
+           graphviz-dot-mode helm helm-bibtex helm-pass helm-swoop htmlize
+           idlwave iedit js2-mode json-mode jsonian jsonrpc kanban keycast
+           ledger-mode magit markdown-mode math-symbol-lists modus-themes
+           neotree ob-restclient ob-swift ob-swiftui org org-outline-numbering
+           org-ql org-re-reveal org-ref org-superstar orgtbl-aggregate
+           osx-dictionary ox-gfm ox-gist ox-jira ox-slack ox-trac package-lint
+           paredit password-store password-store-menu pbcopy pkg-info
+           plantuml-mode project python python-mode rainbow-mode restclient
+           reveal-in-folder scpaste show-font smart-mode-line-powerline-theme
+           snow soap-client solarized-theme spotlight sqlite-mode-extras
+           sr-speedbar svg-clock swift-mode symbol-overlay tj3-mode toc-org
+           track-changes tramp transpose-frame treemacs use-package verilog-mode
+           visual-regexp visual-regexp-steroids vtable webpaste wgrep which-key
            window-tool-bar xref yaml-mode yasnippet yasnippet-snippets ztree))
  '(pixel-scroll-precision-mode t)
  '(plantuml-default-exec-mode 'executable)


### PR DESCRIPTION
- Refactor org-capture-templates to not use doct.
- Change setq to setopt
- Configure variables
  - org-default-notes-file
  - org-protocol-default-template-key
- Add note capture template