### PR TITLE
Cc/markdown tmenu

### DIFF
--- a/cc-markdown-mode.el
+++ b/cc-markdown-mode.el
@@ -90,5 +90,8 @@
 
 (keymap-set markdown-mode-map "M-m" #'cc/markdown-mode-tmenu)
 
+(add-hook 'markdown-mode-hook
+          (lambda () (add-hook 'ediff-prepare-buffer-hook #'outline-show-all 0 t)))
+
 (provide 'cc-markdown-mode)
 ;;; cc-markdown-mode.el ends here

--- a/cc-markdown-mode.el
+++ b/cc-markdown-mode.el
@@ -25,10 +25,13 @@
 ;;; Code:
 (require 'markdown-mode)
 (require 'face-remap)
+(require 'cclisp)
 (require 'cc-save-hooks)
 (require 'cc-style-text-menu)
 (require 'org-table)
 (require 'imenu)
+(require 'casual-lib)
+
 (defvar markdown-mode-map)
 
 (autoload 'markdown-mode "markdown-mode"
@@ -50,6 +53,42 @@
 (add-hook 'markdown-mode-hook #'cc/save-hook-delete-trailing-whitespace)
 (add-hook 'markdown-mode-hook #'imenu-add-menubar-index)
 (add-hook 'markdown-mode-hook (lambda () (setq-local imenu-auto-rescan t)))
+
+(transient-define-prefix cc/markdown-mode-tmenu ()
+  ["Markdown"
+   ["Edit"
+    ("is" "Insert Source Cookie…" cc/markdown-insert-src-cookie)]
+
+   ["Convert"
+    ("mh" "MD Image to HTML" cc/convert-md-image-to-html
+     :inapt-if-not use-region-p)
+
+    ;; ("" "" cc/markdown-to-org-region)
+    ]
+
+   ["Pelican"
+    :pad-keys t
+    ("pt" "Insert Timestamp" cc/pelican-timestamp)
+    ("fi" "Fix image refs" cc/pelican-fix-image-src-refs
+     :inapt-if-not use-region-p)
+    ("S" "Start Server…" cc/devserver)]
+
+   ["Display"
+    ("h" "Hide Markup" markdown-toggle-markup-hiding
+     :description (lambda ()
+                    (casual-lib-checkbox-label
+                     markdown-hide-markup
+                     "Hide Markup"))
+     :transient t)
+    ("P" "Toggle Prettify" prettify-symbols-mode
+     :description (lambda () (casual-lib-checkbox-label prettify-symbols-mode
+                                                   "Prettify")))]]
+
+  [:class transient-row
+   (casual-lib-quit-one)
+   (casual-lib-quit-all)])
+
+(keymap-set markdown-mode-map "M-m" #'cc/markdown-mode-tmenu)
 
 (provide 'cc-markdown-mode)
 ;;; cc-markdown-mode.el ends here

--- a/cc-org-mode.el
+++ b/cc-org-mode.el
@@ -104,7 +104,7 @@ which is done with `org-ctrl-c-ctrl-c'."
                 'company-org-block)))
 
 (add-hook 'org-mode-hook
-          (lambda () (add-hook 'ediff-prepare-buffer-hook #'org-fold-show-all)))
+          (lambda () (add-hook 'ediff-prepare-buffer-hook #'org-fold-show-all 0 t)))
 
 (defun cc/--prettify-components (prefix suffix)
   "Generate a components argument for `prettify-symbols-alist'.

--- a/cclisp.el
+++ b/cclisp.el
@@ -210,7 +210,8 @@ This function presumes that the buffer *pelican* is in the correct directory."
 (defun cc/devserver ()
   "Open Pelican devserver for website chosen by completing read."
   (interactive)
-  (let* ((choice (completing-read "Server: " '("devnull" "captee" "scrim")))
+  (let* ((choice (completing-read "Server: " '("devnull" "captee" "scrim")
+                                  nil nil "devnull"))
          (blog-path (concat "~/Projects/pelican/" choice))
          (blog-buffer (format "*pelican-%s*" choice))
          (cd-blog-path (format "cd %s\n" blog-path)))
@@ -248,6 +249,18 @@ This function presumes that the buffer *pelican* is in the correct directory."
          (rpat "<p align='center'>\n<img src='{static}\\2' alt='' />\n</p>"))
     (save-excursion
       (replace-regexp-in-region pat rpat start end))))
+
+(defun cc/markdown-insert-src-cookie ()
+  "Insert Markdown source block cookie."
+  (interactive)
+  (let ((lang (completing-read "Language: " '("elisp"
+                                               "python"
+                                               "swift"
+                                               "javascript"
+                                               "c"
+                                               "objc"
+                                               "java") nil nil "elisp")))
+    (insert (concat "\n    " "#!" lang))))
 
 (defun cc/slugify (start end)
   "Slugify the region bounded by START and END."


### PR DESCRIPTION
- Add `cc/markdown-mode-tmenu`
- Tune `ediff-prepare-buffer-hook` for org and markdown
- Fix `cc/devserver` to have a default
- Add `cc/markdown-insert-src-cookie`