### PR TITLE
Support Org to Markdown Export / Add Blog Utils

### DIFF
--- a/cc-blog-utils.el
+++ b/cc-blog-utils.el
@@ -1,0 +1,181 @@
+;;; cc-blog-utils.el --- Pelican Blog Utilities  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+;;; Code:
+(require 'org)
+
+
+;; -------------------------------------------------------------------
+;; Misc Functions
+
+(defun cc/pelican-timestamp ()
+  "Insert a timestamp recognized by the Pelican static site generator."
+  (interactive)
+  (insert (format-time-string "%Y-%m-%d %H:%M")))
+
+(defun cc/new-blog-post ()
+  "Create a new blog post in a buffer for “notes from /dev/null”."
+  (interactive)
+    (cd "~/Projects/devnull/content")
+    (find-file (format-time-string "nfdn_%Y_%m_%d_%H%M%S.md"))
+    (yas-insert-snippet))
+
+(defun cc/slugify (start end)
+  "Slugify the region bounded by START and END."
+  (interactive "r")
+  (if (use-region-p)
+      (let ((regionp (buffer-substring start end)))
+        (save-excursion
+          (delete-region start end)
+          (insert
+           (replace-regexp-in-string
+            "[^a-z0-9-]" ""
+            (replace-regexp-in-string
+             "\s+" "-"
+             (downcase regionp))))))))
+
+(defun cc/pelican-fix-image-src-refs (start end)
+  "Fix HTML image src references in region bounded by START and END."
+  (interactive "r")
+  (unless (use-region-p)
+    (error "No region selected"))
+
+  (let* ((pat "src=\\([\\\"']\\)\\(images/.*\\)\\([\\\"']\\)")
+         (rpat "src=\\1{static}\\2\\3"))
+    (save-excursion
+      (replace-regexp-in-region pat rpat start end))))
+
+(defun cc/convert-md-image-to-html (start end)
+  "Convert Markdown image to HTML in region bounded by START and END."
+  (interactive "r")
+  (unless (use-region-p)
+    (error "No region selected"))
+
+  (let* ((pat "\\(!\\[img\\]\\)(\\(images/.*\\))")
+         (rpat "<p align='center'>\n<img src='{static}\\2' alt='' />\n</p>"))
+    (save-excursion
+      (replace-regexp-in-region pat rpat start end))))
+
+(defun cc/markdown-insert-src-cookie ()
+  "Insert Markdown source block cookie."
+  (interactive)
+  (let ((lang (completing-read "Language: " '("elisp"
+                                               "python"
+                                               "swift"
+                                               "javascript"
+                                               "c"
+                                               "objc"
+                                               "java") nil nil "elisp")))
+    (insert (concat "\n    " "#!" lang))))
+
+
+;; -------------------------------------------------------------------
+;; Workflow Functions
+
+(defun cc/blog-draft-post ()
+  "Create draft post for ‘notes from /dev/null’ blog."
+  (interactive)
+
+  (let* ((title (read-string "Title: "))
+         (slug (replace-regexp-in-string
+                "[^a-z0-9-]" ""
+                (replace-regexp-in-string
+                 "\s+" "-"
+                 (downcase title))))
+
+         (datestamp (org-read-date))
+         (filename (concat slug ".org"))
+         (default-directory "~/org/posts")
+         (image-dir (read-string "Image Directory: ")))
+
+    (if (not (string-equal image-dir ""))
+        (make-directory (file-name-concat default-directory "images" image-dir)))
+
+    (switch-to-buffer (create-file-buffer filename))
+    (insert (format "#+TITLE: %s\n" title))
+    (insert (format "#+AUTHOR: %s\n" "Charles Choi"))
+    (insert (format "#+DATE: <%s>\n" datestamp))
+    (insert (format "#+SUMMARY: %s\n" "This is a summary."))
+    (insert (format "#+TAGS: %s\n" "emacs, org mode"))
+    (insert "\n")
+    (insert "Title: {{{title}}}\n")
+    (insert "Date: {{{DATE(%Y-%m-%d %H:%M)}}}\n")
+    (insert (format "Slug: %s\n" slug))
+    (insert "Author: {{{author}}}\n")
+    (insert "Summary: {{{keyword(SUMMARY)}}}\n")
+    (insert "Tags: {{{keyword(TAGS)}}}\n\n")
+    (save-buffer)))
+
+(defun cc/blog-stage-post ()
+  "Create blog stage post for Pelican."
+  (interactive)
+  (org-md-export-as-markdown)
+  (switch-to-buffer "*Org MD Export*")
+  (let* ((content (buffer-substring (point-min) (point-max)))
+         (pat "src=\\([\\\"']\\)\\(images/.*\\)\\([\\\"']\\)")
+         (rpat "src=\\1{static}\\2\\3")
+         (content (replace-regexp-in-string pat rpat content))
+         (target-name (format-time-string "nfdn_%Y_%m_%d_%H%M%S.md")))
+    (cd "~/Projects/devnull/content")
+    (find-file target-name)
+    (insert content)))
+
+
+
+;; -------------------------------------------------------------------
+;; Pelican Server Functions
+
+(defun cc/launch-pelican ()
+  "Launch a local instance of the Pelican static site server.
+This function presumes that the buffer *pelican* is in the correct directory."
+  (interactive)
+  (process-send-string (get-buffer-process "*pelican*") "make devserver\n")
+  (sleep-for 3)
+  (shell-command "open http://localhost:8000"))
+
+(defun cc/devserver ()
+  "Open Pelican devserver for website chosen by completing read."
+  (interactive)
+  (let* ((choice (completing-read "Server: " '("devnull" "captee" "scrim")
+                                  nil nil "devnull"))
+         (blog-path (concat "~/Projects/pelican/" choice))
+         (blog-buffer (format "*pelican-%s*" choice))
+         (cd-blog-path (format "cd %s\n" blog-path)))
+
+    (if (get-buffer blog-buffer)
+        (switch-to-buffer blog-buffer)
+      (progn
+        (shell-new)
+        (rename-buffer blog-buffer)
+        (process-send-string (get-buffer-process blog-buffer) "cd ~/Projects/pelican\n")
+        (process-send-string (get-buffer-process blog-buffer) "source .venv/bin/activate\n")
+        (process-send-string (get-buffer-process blog-buffer) cd-blog-path)
+        (setq-local default-directory blog-path)
+        (if (display-graphic-p)
+            (cc/launch-pelican))))))
+
+
+(provide 'cc-blog-utils)
+
+;;; cc-blog-utils.el ends here

--- a/cc-markdown-mode.el
+++ b/cc-markdown-mode.el
@@ -30,6 +30,7 @@
 (require 'cc-style-text-menu)
 (require 'org-table)
 (require 'imenu)
+(require 'cc-blog-utils)
 (require 'casual-lib)
 
 (defvar markdown-mode-map)

--- a/ccinit.el
+++ b/ccinit.el
@@ -124,6 +124,7 @@
 (require 'cc-bibtex-mode)
 (require 'cc-eww-mode)
 (require 'cc-debbugs-mode)
+(require 'cc-blog-utils)
 (require 'ffap)
 (require 'calle24)
 (require 'scrim-utils)
@@ -178,6 +179,14 @@
     (xterm-mouse-mode 1)
     (global-set-key (kbd "<mouse-4>") 'scroll-down-line)
     (global-set-key (kbd "<mouse-5>") 'scroll-up-line)))
+
+(defun cc/workplace ()
+  "Initialize workplace."
+  (interactive)
+  (cc/frame-resize nil)
+  (status-report)
+  (org-agenda nil "n")
+  (eshell t))
 
 ;; (password-store-menu-enable)
 

--- a/cclisp.el
+++ b/cclisp.el
@@ -187,95 +187,6 @@ If prefix ARG is invoked, then macOS open is used to open the PDF file."
   (declare (pure t) (side-effect-free t))
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
-(defun cc/pelican-timestamp ()
-  "Insert a timestamp recognized by the Pelican static site generator."
-  (interactive)
-  (insert (format-time-string "%Y-%m-%d %H:%M")))
-
-(defun cc/new-blog-post ()
-  "Create a new blog post in a buffer for “notes from /dev/null”."
-  (interactive)
-    (cd "~/Projects/devnull/content")
-    (find-file (format-time-string "nfdn_%Y_%m_%d_%H%M%S.md"))
-    (yas-insert-snippet))
-
-(defun cc/launch-pelican ()
-  "Launch a local instance of the Pelican static site server.
-This function presumes that the buffer *pelican* is in the correct directory."
-  (interactive)
-  (process-send-string (get-buffer-process "*pelican*") "make devserver\n")
-  (sleep-for 3)
-  (shell-command "open http://localhost:8000"))
-
-(defun cc/devserver ()
-  "Open Pelican devserver for website chosen by completing read."
-  (interactive)
-  (let* ((choice (completing-read "Server: " '("devnull" "captee" "scrim")
-                                  nil nil "devnull"))
-         (blog-path (concat "~/Projects/pelican/" choice))
-         (blog-buffer (format "*pelican-%s*" choice))
-         (cd-blog-path (format "cd %s\n" blog-path)))
-
-    (if (get-buffer blog-buffer)
-        (switch-to-buffer blog-buffer)
-      (progn
-        (shell-new)
-        (rename-buffer blog-buffer)
-        (process-send-string (get-buffer-process blog-buffer) "cd ~/Projects/pelican\n")
-        (process-send-string (get-buffer-process blog-buffer) "source .venv/bin/activate\n")
-        (process-send-string (get-buffer-process blog-buffer) cd-blog-path)
-        (setq-local default-directory blog-path)
-        (if (display-graphic-p)
-            (cc/launch-pelican))))))
-
-(defun cc/pelican-fix-image-src-refs (start end)
-  "Fix HTML image src references in region bounded by START and END."
-  (interactive "r")
-  (unless (use-region-p)
-    (error "No region selected"))
-
-  (let* ((pat "src=\\([\\\"']\\)\\(images/.*\\)\\([\\\"']\\)")
-         (rpat "src=\\1{static}\\2\\3"))
-    (save-excursion
-      (replace-regexp-in-region pat rpat start end))))
-
-(defun cc/convert-md-image-to-html (start end)
-  "Convert Markdown image to HTML in region bounded by START and END."
-  (interactive "r")
-  (unless (use-region-p)
-    (error "No region selected"))
-
-  (let* ((pat "\\(!\\[img\\]\\)(\\(images/.*\\))")
-         (rpat "<p align='center'>\n<img src='{static}\\2' alt='' />\n</p>"))
-    (save-excursion
-      (replace-regexp-in-region pat rpat start end))))
-
-(defun cc/markdown-insert-src-cookie ()
-  "Insert Markdown source block cookie."
-  (interactive)
-  (let ((lang (completing-read "Language: " '("elisp"
-                                               "python"
-                                               "swift"
-                                               "javascript"
-                                               "c"
-                                               "objc"
-                                               "java") nil nil "elisp")))
-    (insert (concat "\n    " "#!" lang))))
-
-(defun cc/slugify (start end)
-  "Slugify the region bounded by START and END."
-  (interactive "r")
-  (if (use-region-p)
-      (let ((regionp (buffer-substring start end)))
-        (save-excursion
-          (delete-region start end)
-          (insert
-           (replace-regexp-in-string
-            "[^a-z0-9-]" ""
-            (replace-regexp-in-string
-             "\s+" "-"
-             (downcase regionp))))))))
-
 (defun cc/posix-timestamp-to-human (start end)
   "Convert a POSIX timestamp bounded by START and END to RFC 822 and \
 ISO 8601."
@@ -985,20 +896,48 @@ Code from https://mbork.pl/2021-05-02_Org-mode_to_Markdown_via_the_clipboard"
               (org-export-string-as region 'md t '(:with-toc nil))))
         (gui-set-selection 'CLIPBOARD markdown))))
 
-(defun cc/yank-markdown-as-org ()
-  "Yank Markdown text as Org.
+;; (defun cc/yank-markdown-as-org ()
+;;   "Yank Markdown text as Org.
 
-This command will convert Markdown text in the top of the `kill-ring'
-and convert it to Org using the pandoc utility."
-  (interactive)
+;; This command will convert Markdown text in the top of the `kill-ring'
+;; and convert it to Org using the pandoc utility."
+;;   (interactive)
+;;   (save-excursion
+;;     (with-temp-buffer
+;;       (yank)
+;;       (shell-command-on-region
+;;        (point-min) (point-max)
+;;        "pandoc -f markdown -t org --wrap=preserve" t t)
+;;       (kill-region (point-min) (point-max)))
+;;     (yank)))
+
+(defun cc/yank-markdown-as-org (&optional level)
+  "Yank Markdown text as Org at optional prefix LEVEL.
+
+This command will convert Markdown text in the top of the `kill-ring' to
+Org before yanking (pasting) the converted text.
+
+The command `org-paste-subtree' is used to yank the converted text and
+has behavior that can be modified with a `\\[universal-argument]'
+prefix. Using prefixes, `org-paste-subtree' can yank text at different
+structure levels. The argument LEVEL captures this prefix and passes it
+along to `org-paste-subtree'. A deep reading of how `org-paste-subtree'
+handles prefixes is recommended.
+
+The actual Markdown to Org conversion is accomplished with the command
+line utility pandoc. See the man page `pandoc(1)' for details."
+  (interactive "P")
   (save-excursion
     (with-temp-buffer
       (yank)
       (shell-command-on-region
        (point-min) (point-max)
        "pandoc -f markdown -t org --wrap=preserve" t t)
-      (kill-region (point-min) (point-max)))
-    (yank)))
+      (org-mode)
+      (goto-char (point-min))
+      (org-cut-subtree))
+    ;; (call-interactively #'org-paste-subtree)
+    (org-paste-subtree level)))
 
 (defun cc/split-window-right ()
   "Invoke `split-window-right', making the new window active."


### PR DESCRIPTION
- Support Org to Markdown export by system clipboard.
- Refactor cc/yank-markdown-as-org to support subtree level.
- Reorganize Blog/Pelican functions into `cc-blog-utils.el`.
- Also add `cc/workflow`.