### PR TITLE
Configure Transient menus for Org and Misc Changes

### DIFF
--- a/cc-blog-utils.el
+++ b/cc-blog-utils.el
@@ -144,7 +144,11 @@
     (insert content)
     (goto-char (point-min))
     (re-search-forward "^Tags:")
-    (flush-lines "^$" (point-min) (point) t)))
+    (flush-lines "^$" (point-min) (point) t)
+    (save-excursion
+      (goto-char (point-min))
+      (while (search-forward "content/nfdn" nil t)
+        (replace-match "{filename}nfdn")))))
 
 
 ;; -------------------------------------------------------------------

--- a/cc-calc-mode.el
+++ b/cc-calc-mode.el
@@ -31,9 +31,11 @@
 (add-hook 'calc-mode-hook (lambda () (setq calc-gnuplot-default-device "aqua")))
 
 (keymap-set calc-mode-map "C-o" #'casual-calc-tmenu)
+(keymap-set calc-mode-map "C-c v" #'casual-calc-variable-crud-tmenu)
+(keymap-set calc-mode-map "<clear>" #'calc-pop)
+
 (keymap-set calc-alg-map "C-o" #'casual-calc-tmenu)
 
-(keymap-set calc-mode-map "<clear>" #'calc-pop)
 
 (defun cc/ptop ()
   "Print top of Calc stack."

--- a/cc-context-menu.el
+++ b/cc-context-menu.el
@@ -115,7 +115,13 @@ temporarily visible (Visible mode)"])
                     ["Paste Markdown as Org"
                      cc/yank-markdown-as-org
                      :visible (derived-mode-p 'org-mode)
-                     :help "Paste Markdown text in clipboard (kill-ring) as Org"]))
+                     :help "Paste Markdown text in clipboard (kill-ring) as Org"])
+
+      (easy-menu-add-item menu nil
+                    ["Paste Media"
+                     yank-media
+                     :visible (derived-mode-p 'org-mode)
+                     :help "Paste (yank) media"]))
 
      ((derived-mode-p 'markdown-mode)
       (cc/context-menu-item-separator menu markdown-mode-operations-separator)
@@ -199,7 +205,11 @@ temporarily visible (Visible mode)"])
 
     (easy-menu-add-item menu nil ["Agenda - All TODOs"
                                   (lambda () (interactive)(org-agenda nil "n"))
-                                  :help "Show Org agenda with all TODO tasks."])
+                                  :help "Show Org agenda with all TODO tasks"])
+
+    (easy-menu-add-item menu nil ["Add Note"
+                                  (lambda () (interactive)(org-capture nil "j"))
+                                  :help "Add journal note"])
 
     (easy-menu-add-item menu nil ["Scratch"
                                   scratch-buffer
@@ -334,6 +344,24 @@ to the current subtree"])))
                              :help "Remove narrowing restrictions \
 from current buffer"])))))
 
+
+(easy-menu-define cc/org-table-region-menu nil
+  "Key map for Org table region sub-menu."
+  '("Org Table Region"
+    ["Cut"
+     org-table-cut-region
+     :enable (and (bound-and-true-p rectangle-mark-mode) (use-region-p))
+     :help "Cut Org table region"]
+
+    ["Copy"
+     org-table-copy-region
+     :enable (and (bound-and-true-p rectangle-mark-mode) (use-region-p))
+     :help "Copy Org table region"]
+
+    ["Paste"
+     org-table-paste-rectangle
+     :help "Paste Org table region"]))
+
 (defun cc/context-menu-org-table-items (menu &optional inapt)
   "Menu items to populate MENU for Org table section if INAPT nil.
 
@@ -344,15 +372,19 @@ clear it."
     (cc/context-menu-item-separator menu org-table-sqeparator)
     (easy-menu-add-item menu nil
                         ["Table Cell Info"
-                         cc/mouse-copy-org-table-reference-dwim
-                         :label (cc/org-table-reference-dwim)
+                         casual-org-table-copy-reference-dwim
+                         :label (casual-org-table--reference-dwim)
                          :help "Copy Org table reference (field or range) into kill ring via mouse"])
+
+    (easy-menu-add-item menu nil cc/org-table-region-menu)
+
     (easy-menu-add-item menu nil
                         ["Show Coordinates"
                          org-table-toggle-coordinate-overlays
                          :style toggle
                          :selected org-table-coordinate-overlays
                          :help "Toggle the display of row/column numbers in tables"])
+
     (easy-menu-add-item menu nil
                         ["Edit Table Formulas"
                          org-table-edit-formulas

--- a/cc-dired-mode.el
+++ b/cc-dired-mode.el
@@ -25,6 +25,7 @@
 ;;; Code:
 (require 'dired)
 (require 'dired-x)
+(require 'dired-async)
 (require 'cclisp)
 (require 'wdired)
 (require 'image-dired)
@@ -53,6 +54,8 @@
 (keymap-set dired-mode-map "M-p" #'dired-prev-dirline)
 (keymap-set dired-mode-map "]" #'dired-next-subdir)
 (keymap-set dired-mode-map "[" #'dired-prev-subdir)
+(keymap-set dired-mode-map "M-]" #'dired-next-marked-file)
+(keymap-set dired-mode-map "M-[" #'dired-prev-marked-file)
 (keymap-set dired-mode-map "M-j" #'dired-goto-subdir)
 (keymap-set dired-mode-map ";" #'image-dired-dired-toggle-marked-thumbs)
 (keymap-set dired-mode-map "<f1>" #'avy-goto-end-of-line)
@@ -70,6 +73,17 @@
 (keymap-set image-dired-thumbnail-mode-map "p" #'image-dired-display-previous)
 
 (add-hook 'wdired-mode-hook #'superword-mode)
+
+(defun cc/casual-dired-subsystem (subsystem)
+  "Create Dired buffer in Casual project filtering SUBSYSTEM."
+  (interactive "sSub-system: ")
+  (let* ((pattern (format ".%s.*el$" subsystem))
+         (bname (format "*casual-%s*" subsystem)))
+    (if (get-buffer bname)
+        (kill-buffer bname))
+    (find-file "~/Projects/elisp/casual")
+    (casual-dired-find-dired-regexp pattern)
+    (rename-buffer bname)))
 
 (provide 'cc-dired-mode)
 ;;; cc-dired-mode.el ends here

--- a/cc-ediff-mode.el
+++ b/cc-ediff-mode.el
@@ -28,9 +28,58 @@
 
 (casual-ediff-install)
 
+;; Oh dang, this looks like it works…
+;; (defun cc/ediff-show-text-all ()
+;;   "Expand all Org headings in the data buffers for Ediff."
+;;   (dolist (b (list (and (boundp 'ediff-buffer-A) ediff-buffer-A)
+;;                    (and (boundp 'ediff-buffer-B) ediff-buffer-B)
+;;                    (and (boundp 'ediff-buffer-C) ediff-buffer-C)))
+;;     (when (buffer-live-p b)
+;;       (with-current-buffer b
+;;         (cond
+;;          ((derived-mode-p 'org-mode)
+;;           (if (fboundp 'org-fold-show-all) (org-fold-show-all))
+;;           (if (fboundp 'visible-mode) (visible-mode nil))
+;;           (if (fboundp 'org-remove-inline-images) (org-remove-inline-images)))
+
+;;          ((derived-mode-p 'markdown-mode)
+;;           (if (fboundp 'outline-show-all) (outline-show-all))
+;;           (if (fboundp 'markdown-toggle-markup-hiding)
+;;               (markdown-toggle-markup-hiding -1))
+;;           (if (fboundp 'markdown-remove-inline-images)
+;;               (markdown-remove-inline-images)))
+
+;;          (t nil))))))
+
+;; (add-hook 'ediff-startup-hook #'cc/ediff-show-text-all)
+
+(defun cc/ediff-text-mode-hook ()
+  "Hook for revealing text mode."
+  (cond
+   ((derived-mode-p 'org-mode)
+    (if (fboundp 'org-fold-show-all) (org-fold-show-all))
+    (if (fboundp 'visible-mode) (visible-mode nil))
+    (if (fboundp 'org-remove-inline-images) (org-remove-inline-images)))
+
+   ((derived-mode-p 'markdown-mode)
+    (if (fboundp 'outline-show-all) (outline-show-all))
+    (if (fboundp 'markdown-toggle-markup-hiding)
+        (markdown-toggle-markup-hiding -1))
+    (if (fboundp 'markdown-remove-inline-images)
+        (markdown-remove-inline-images)))
+
+   (t (if (fboundp 'outline-show-all) (outline-show-all)))))
+
+(add-hook 'ediff-prepare-buffer-hook #'cc/ediff-text-mode-hook)
+
 (add-hook 'ediff-keymap-setup-hook
           (lambda ()
             (keymap-set ediff-mode-map "C-o" #'casual-ediff-tmenu)))
+
+;; (add-hook 'ediff-after-setup-windows-hook (lambda () (call-interactively
+;;                                                  'casual-ediff-tmenu)))
+
+;;(add-hook 'ediff-mode-hook (lambda () (call-interactively casual-ediff-tmenu)))
 
 (provide 'cc-ediff-mode)
 ;;; cc-ediff-mode.el ends here

--- a/cc-eww-mode.el
+++ b/cc-eww-mode.el
@@ -31,6 +31,8 @@
 
 (add-hook 'eww-mode-hook #'hl-line-mode)
 (add-hook 'eww-bookmark-mode-hook #'hl-line-mode)
+(add-hook 'eww-mode-hook (lambda ()
+                           (setq-local scroll-margin 12)))
 
 (defun cc/eww-point-on-first-line-p ()
   "Return t if the point is on the first line, nil otherwise.
@@ -95,11 +97,6 @@ This function taken via GitHub Copilot query."
 
 (keymap-set eww-mode-map "P" #'casual-eww-backward-paragraph-link)
 (keymap-set eww-mode-map "N" #'casual-eww-forward-paragraph-link)
-
-;;(keymap-set eww-mode-map "p" #'backward-paragraph)
-
-;; (keymap-set eww-mode-map "n" #'next-line)
-;; (keymap-set eww-mode-map "p" #'previous-line)
 
 (keymap-set eww-mode-map "M-l" #'eww)
 

--- a/cc-global-keybindings.el
+++ b/cc-global-keybindings.el
@@ -178,8 +178,20 @@
 (keymap-global-set "C-<kp-2>" #'windmove-down)
 (keymap-global-set "C-<kp-4>" #'windmove-left)
 (keymap-global-set "C-<kp-6>" #'windmove-right)
+
+(keymap-global-set "M-<kp-8>" #'windmove-swap-states-up)
+(keymap-global-set "M-<kp-5>" #'windmove-swap-states-down)
+(keymap-global-set "M-<kp-2>" #'windmove-swap-states-down)
+(keymap-global-set "M-<kp-4>" #'windmove-swap-states-left)
+(keymap-global-set "M-<kp-6>" #'windmove-swap-states-right)
+
 (keymap-global-set "C-<kp-0>" #'ace-select-window)
 (keymap-global-set "C-<kp-divide>" #'transpose-frame)
+
+(keymap-global-set "C-c w" #'casual-editkit-windows-tmenu)
+(keymap-global-set "C-c r" #'casual-editkit-rectangle-tmenu)
+(keymap-global-set "C-c g" #'casual-editkit-registers-tmenu)
+(keymap-global-set "C-c p" #'casual-editkit-project-tmenu)
 
 (keymap-set minibuffer-local-shell-command-map "M-b" #'backward-sexp)
 (keymap-set minibuffer-local-shell-command-map "M-f" #'cc/next-sexp)

--- a/cc-info-mode.el
+++ b/cc-info-mode.el
@@ -49,6 +49,7 @@
 (keymap-set Info-mode-map "<mouse-4>" #'Info-history-back)
 (keymap-set Info-mode-map "s-<tab>" #'cc/clone-in-new-tab)
 (keymap-set Info-mode-map "M-t" #'cc/clone-in-new-tab)
+(keymap-set Info-mode-map "." #'Info-up)
 
 (provide 'cc-info-mode)
 ;;; cc-info-mode.el ends here

--- a/cc-insert-org-plot.el
+++ b/cc-insert-org-plot.el
@@ -78,7 +78,7 @@ will be displayed."
   (cc/org-plot-insert-snippet "org-plot histogram image"))
 
 (easy-menu-define cc/insert-org-plot-menu nil
-  "Kaymap for Org Plot submenu"
+  "Key map for Org Plot sub-menu."
   '("Org Plot"
     ["Lines - GUI"
      cc/org-plot-insert-lines-plot

--- a/cc-macros.el
+++ b/cc-macros.el
@@ -1,0 +1,36 @@
+;;; cc-macros.el --- My Macros -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  Charles Choi
+
+;; Author: Charles Choi <charles.choi@yummymelon.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(defalias 'cc/convert-to-menu-testcase
+  (kmacro "C-a C-f c a s u a l t - a d d - t e s t c a s e SPC M-] C-o k SPC # ' C-d M-] SPC t e s t - v e c t o r s C-n C-a"))
+
+(defalias 'cc/casual-suffix-to-test
+  (kmacro "C-<down> C-<right> C-<right> C-o c C-<up> C-e <return> ( c a s u a l t - m o c k SPC # ' C-y C-<up> C-p C-<down> : b i n d i n g SPC C-<right> C-o k : c o m m a n d C-<up>"))
+
+(defalias 'cc/casual-unicode-to-test
+   (kmacro "C-a C-<down> C-o m ( c a s u a l - o r g - u n i c o d e - g e t SPC C-<up> C-o k C-<up> M-] <return> C-y C-a C-o m ( s t r i n g - e q u a l SPC C-<up> C-o m ( s h o u l d SPC C-<up> C-o e D <return> C-p C-<down> C-o k C-<down> C-o k C-<up> C-<up> C-n C-n C-<down> C-<down> C-<right> C-<right> SPC C-y C-<up> C-<up> C-p C-p C-<down> C-<down> C-o k C-<up> C-<up> C-n C-<down> C-<down> C-<right> C-<right> C-y C-<up> C-<up> C-p C-k C-k TAB"))
+
+(provide 'cc-macros)
+;;; cc-macros.el ends here

--- a/cc-markdown-mode.el
+++ b/cc-markdown-mode.el
@@ -91,8 +91,8 @@
 
 (keymap-set markdown-mode-map "M-m" #'cc/markdown-mode-tmenu)
 
-(add-hook 'markdown-mode-hook
-          (lambda () (add-hook 'ediff-prepare-buffer-hook #'outline-show-all 0 t)))
+;; (add-hook 'markdown-mode-hook
+;;           (lambda () (add-hook 'ediff-prepare-buffer-hook #'outline-show-all 0 t)))
 
 (provide 'cc-markdown-mode)
 ;;; cc-markdown-mode.el ends here

--- a/cc-org-mode.el
+++ b/cc-org-mode.el
@@ -40,7 +40,7 @@
 (require 'casual-agenda)
 (require 'cc-style-text-menu)
 (require 'org-protocol)
-;;(require 'casual-calendar)
+(require 'casual-org)
 
 (if (eq system-type 'darwin)
     (require 'ob-swiftui))
@@ -67,22 +67,12 @@ which is done with `org-ctrl-c-ctrl-c'."
   (interactive)
   (org-ctrl-c-ctrl-c '(4)))
 
-(setopt org-default-notes-file "~/org/notes.org")
-
-(setopt org-todo-keywords
-           '((sequence "TODO(t)" "IN_PROGRESS(i)" "WAITING(w)" "|" "DONE(d)")
-             (sequence "|" "CANCELED(c)")))
-
 ;; (setq org-todo-keyword-faces
 ;;       '(("TODO" . "red")
 ;;         ("IN_PROGRESS" . "dark orange")
 ;;         ("WAITING" . "dark orange")
 ;;         ("DONE" . "sea green")
 ;;         ("CANCELED" . (:foreground "blue" :weight bold))))
-
-(setopt org-refile-targets
-      '((nil :maxlevel . 3)
-        (org-agenda-files :maxlevel . 3)))
 
 ;;(setq org-log-done 'time)
 
@@ -94,7 +84,6 @@ which is done with `org-ctrl-c-ctrl-c'."
 (add-hook 'org-mode-hook (lambda ()
                            (cc/reconfig-org-smart-quotes-lang "en")))
 
-(setopt org-imenu-depth 7)
 (add-hook 'org-mode-hook #'imenu-add-menubar-index)
 (add-hook 'org-mode-hook (lambda () (setq-local imenu-auto-rescan t)))
 (add-hook
@@ -103,8 +92,8 @@ which is done with `org-ctrl-c-ctrl-c'."
    (add-to-list (make-local-variable 'company-backends)
                 'company-org-block)))
 
-(add-hook 'org-mode-hook
-          (lambda () (add-hook 'ediff-prepare-buffer-hook #'org-fold-show-all 0 t)))
+;; (add-hook 'org-mode-hook
+;;           (lambda () (add-hook 'ediff-prepare-buffer-hook #'org-fold-show-all 0 t)))
 
 (defun cc/--prettify-components (prefix suffix)
   "Generate a components argument for `prettify-symbols-alist'.
@@ -282,120 +271,18 @@ SUFFIX - string appended to prefix
 
 (require 'cc-org-capture)
 
-(transient-define-prefix cc/org-mode-tmenu ()
-  ["Org"
-   :description (lambda () (if (org-at-table-p)
-                          (format "Org %s" (cc/org-table-reference-dwim))
-                        "Org"))
+(defun cc/disable-flycheck-in-org-src-block ()
+  (setq-local flycheck-disabled-checkers '(emacs-lisp-checkdoc)))
 
-   :if-not org-at-table-p
-   ["State"
-    :if-not org-at-table-p
-    ("t" "TODO…" org-todo)
-    ("I" "⏱️ In" org-clock-in
-     :if-not org-clocking-p)
-    ("O" "⏱️ Out" org-clock-out
-     :if org-clocking-p)
-    ("R" "⏱️ Report" org-clock-report)]
+(add-hook 'org-src-mode-hook 'cc/disable-flycheck-in-org-src-block)
 
-   ["Mark"
-    ("ms" "Subtree" org-mark-subtree)
-    ("me" "Element" org-mark-element)]
+
+;; -------------------------------------------------------------------
+;; Transients
 
-   ["Timestamp"
-    ("." "Add…" org-timestamp)
-    ("i" "Inactive…" org-timestamp-inactive)]
-
-   ["Link"
-    ("l" "Insert…" org-insert-link)
-    ("L" "Last" org-insert-last-stored-link)]
-
-   ["Schedule"
-    ("C-s" "Schedule…" org-schedule)
-    ("C-d" "Deadline…" org-deadline)]
-
-   ["Annotate"
-    ("p" "Property…" org-set-property)
-    (":" "Tags…" org-set-tags-command)]]
-
-  ["Org Table"
-   :if org-at-table-p
-   :description (lambda () (format "Org Table: %s" (cc/org-table-reference-dwim)))
-   ["Table"
-    ("r" "Copy Reference" cc/copy-org-table-reference-dwim :transient t)
-    ;; ("{" "Toggle Debugger" org-table-toggle-formula-debugger :transient t)
-    ("E" "Export…" org-table-export)
-    ("p" "Run Gnuplot" org-plot/gnuplot :transient t)]
-
-   ["Edit"
-    :pad-keys t
-    ("C-SPC" "Mark" set-mark-command :transient t)
-    ("`" "Field" org-table-edit-field :transient nil)
-    ("f" "Formula*" org-table-eval-formula)
-    ("DEL" "Blank" org-table-blank-field :transient t)
-    ("F" "Formulas" org-table-edit-formulas :transient nil)]
-
-   ;; ["Region"  ; this does not work with Transient, dunno why.
-   ;;  ("W" "Copy" org-table-copy-region :transient t)
-   ;;  ("C" "Cut" org-table-cut-region :transient t)
-   ;;  ("Y" "Paste" org-table-paste-rectangle :transient t)]
-
-   ["Compute"
-    ("c" "Row" org-table-recalculate :transient t)
-    ("a" "All Tables" org-table-recalculate-buffer-tables :transient t)
-    ("s" "Sum" org-table-sum)
-    ("S" "Sort" org-table-sort-lines)
-    ("T" "Transpose" org-table-transpose-table-at-point :transient t)
-    ("if" "Info - Functions" (lambda ()
-                               (interactive)
-                               (info "(calc) Function Index")))]
-
-   ["Display"
-    ("t" "Toggle Coordinates" org-table-toggle-coordinate-overlays :transient t)
-    ("h" "Header Line" org-table-header-line-mode :transient t)
-    ]
-   ]
-
-  ["Edit"
-   :if-not org-at-table-p
-   [("b" "Add Block…" org-insert-structure-template)
-    ("r" "Insert Cite…" org-cite-insert)
-    ("y" "Yank Markdown" cc/yank-markdown-as-org)]
-   [("c" "Capture…" org-capture)
-    ("P" "Toggle Prettify" prettify-symbols-mode
-     :description (lambda () (casual-lib-checkbox-label prettify-symbols-mode
-                                                   "Prettify")))]
-   [("s" "Sort…" org-sort)
-    ("e" "Export…" org-export-dispatch)]
-   [("C" "Clone…" org-clone-subtree-with-time-shift)
-    ("-" "^c -…" org-ctrl-c-minus :transient t)]
-   [("n" "Note…" org-add-note)
-    ("w" "Refile…" org-refile)
-    ("v" "Copy Visible" org-copy-visible)]]
-
-
-  ["Navigation"
-   :pad-keys t
-   [("TAB" "Cycle" org-cycle :transient t)
-    ("S-TAB" "S-Cycle" org-shifttab :transient t)]
-   [("C-p" "↑" previous-line :transient t)
-    ("C-n" "↓" next-line :transient t)]
-   [("C-b" "↑" backward-char :transient t)
-    ("C-f" "↓" forward-char :transient t)]
-
-   [:if org-at-table-p
-    ("M-a" "⇤" org-table-beginning-of-field :transient t)
-    ("M-e" "⇥" org-table-end-of-field :transient t)]
-   ]
-
-
-  [:class transient-row
-   (casual-lib-quit-one)
-   ("RET" "Dismiss" transient-quit-all)
-   ("U" "Undo" undo :transient t)
-   (casual-lib-quit-all)])
-
-(keymap-set org-mode-map "M-m" #'cc/org-mode-tmenu)
+(keymap-set org-mode-map "M-m" #'casual-org-tmenu)
+(keymap-set org-table-fedit-map "M-m" #'casual-org-table-fedit-tmenu)
+(keymap-set org-table-fedit-map "<f1>" #'casual-org-table-fedit-tmenu)
 
 ;; ox-gfm init is so broken. need to load it manually.
 (eval-after-load "org"

--- a/cc-prog-mode.el
+++ b/cc-prog-mode.el
@@ -49,10 +49,12 @@
 (add-hook 'prog-mode-hook #'flyspell-prog-mode)
 (add-hook 'prog-mode-hook #'goto-address-prog-mode)
 (add-hook 'prog-mode-hook #'cc/save-hook-delete-trailing-whitespace)
-(add-hook 'prog-mode-hook (lambda nil
-                            (condition-case err (imenu-add-menubar-index)
-                              (imenu-unavailable
-                               (message (error-message-string err))))))
+(add-hook 'prog-mode-hook
+          (lambda nil
+            (condition-case err (imenu-add-menubar-index)
+              (imenu-unavailable
+               (let ((inhibit-message t))
+                 (message "Warning: %s" (error-message-string err)))))))
 
 (add-hook 'prog-mode-hook
           (lambda ()

--- a/ccinit.el
+++ b/ccinit.el
@@ -99,7 +99,6 @@
 (require 'cc-swift-mode)
 (require 'flyspell)
 (require 'cc-view-mode)
-(require 'cc-global-keybindings)
 (require 'cc-magit-mode)
 (require 'cc-menu-reconfig)
 (require 'cc-compile-mode)
@@ -127,11 +126,14 @@
 (require 'cc-blog-utils)
 (require 'cc-css-mode)
 (require 'cc-html-mode)
+(require 'cc-macros)
 (require 'ffap)
 (require 'calle24)
 (require 'scrim-utils)
 (require 'numeri)
 (require 'casual-agenda)
+(require 'cc-global-keybindings)
+
 
 ;;; Configure MELPA Packages
 (require 'casual-isearch)

--- a/cclisp.el
+++ b/cclisp.el
@@ -118,7 +118,10 @@ A new frame will be created if `pop-up-frames' is t."
 (defun dictate()
    "Open a default text file to dictate into using macOS open."
    (interactive)
-   (shell-command "open ~/Documents/Dictation.rtf"))
+   (let ((fname (file-name-concat "~/org/dictation"
+                                  (format-time-string "%Y%m%d_%H%M%S.txt"))))
+     (shell-command (format "touch %s" fname))
+     (shell-command (format "open -a TextEdit.app %s" fname))))
 
 ;; TODO: revisit storing web links
 (load-file (concat user-emacs-directory "url-bookmarks.el"))
@@ -261,6 +264,16 @@ ISO 8601."
   "Insert a menu symbol."
   (interactive)
   (insert "›"))
+
+(defun cc/prefix-symbol ()
+  "Insert a prefix symbol."
+  (interactive)
+  (insert "✦"))
+
+(defun cc/info-symbol ()
+  "Insert a info symbol."
+  (interactive)
+  (insert "ⓘ"))
 
 (defun cc/apple-maps-search(&optional input)
   "Search Apple Maps with INPUT.
@@ -611,8 +624,6 @@ V is either nil or non-nil."
   (occur "^.*<f[[:digit:]]*>")
   (delete-other-windows))
 
-(defalias 'cc/convert-to-menu-testcase
-  (kmacro "C-a C-f c a s u a l t - a d d - t e s t c a s e SPC M-] C-o k SPC # ' C-d M-] SPC t e s t - v e c t o r s C-n C-a"))
 
 (defun cc/find-test-file ()
   "Open test file in other window."
@@ -622,195 +633,6 @@ V is either nil or non-nil."
     (find-file-other-window test-name)
     (transpose-frame)))
 
-;; Org Table Functions
-
-(defun cc/org-table-cell-at-point ()
-  "At point, return the cell object from an Org table.
-
-A cell object is defined to be a list containing the row and the
-column, successively."
-  (if (not (org-at-table-p))
-      (error "Not in a table"))
-
-  (let* ((row (org-table-current-dline))
-         (col (org-table-current-column)))
-    (list row col)))
-
-(defun cc/format-org-table-field-reference (cell)
-  "Format CELL object into @r$c format.
-
-CELL object obtained via `cc/org-table-cell-at-point'.
-
-See Info node `(org) References' for more on Org table field
-reference format."
-  (let ((row (nth 0 cell))
-        (col (nth 1 cell)))
-    (format "@%d$%d" row col)))
-
-(defun cc/org-table-range ()
-  "Return range object from a region defined within an Org table.
-
-A range object is a list of two cells computed via
-`cc/org-table-cell-at-point', the first being the cell at the
-start of the region and the last being the cell at the end of the
-region."
-  (if (not (and (org-at-table-p) (use-region-p)))
-      (error "Not in an Org table"))
-
-  (save-excursion
-    (let* ((end (cc/org-table-cell-at-point)))
-      (exchange-point-and-mark)
-      (let ((start (cc/org-table-cell-at-point)))
-        (list start end)))))
-
-(defvar cc/last-org-table-reference nil
-  "Last stored Org table reference.
-
-State variable to store an Org table reference (field or range)
-to be used in an Org table formula. This variable is set via
-`cc/org-table-reference-dwim'
-
-NOTE: This state variable to work-around my lack of clarity on
-region and mouse menu interaction.")
-
-(defun cc/org-table-reference-dwim ()
-  "Org table reference given point or region is defined.
-
-Return Org table reference (field or range) depending on whether
-a point or region is defined in an Org table.
-
-If the region is defined over multiple columns, then a Calc
-vector matrix is returned. See Info node `(org) Formula syntax
-for Calc' for more.
-
-Calling this function will set `cc/last-org-table-reference'.
-
-See Info node `(org) References' for more on Org table field
-reference format."
-  (if (not (org-at-table-p))
-      (error "Not in an Org table"))
-
-  (cond
-   ((use-region-p)
-
-    (let* ((range (cc/org-table-range))
-           (start (nth 0 range))
-           (end (nth 1 range))
-           (msg (format "%s..%s"
-                        (cc/format-org-table-field-reference start)
-                        (cc/format-org-table-field-reference end))))
-      (setq cc/last-org-table-reference (cc/org-table-range-to-reference range))
-      msg))
-
-   (t
-    (let ((msg (cc/format-org-table-field-reference (cc/org-table-cell-at-point))))
-      (setq cc/last-org-table-reference msg)
-      msg))))
-
-(defun cc/copy-org-table-reference-dwim ()
-  "Copy Org table reference (field or range) into kill ring.
-
-Given a point or region defined in an Org table, add to the
-`kill-ring' an Org table field or range reference.
-
-If the region is defined over multiple columns, then a Calc
-vector matrix is returned. See Info node `(org) Formula syntax
-for Calc' for more.
-
-If the buffer *Edit Formulas* is available (usually via
-`org-table-edit-formulas'), the reference will be inserted into
-it.
-
-See Info node `(org) References' for more on Org table field
-reference format."
-  (interactive)
-  (if (not (org-at-table-p))
-      (error "Not in an Org table"))
-
-  (let ((msg (cc/org-table-reference-dwim))
-        (formulas-buffer (get-buffer "*Edit Formulas*")))
-    (if formulas-buffer
-        (with-current-buffer formulas-buffer
-          (insert cc/last-org-table-reference)))
-    (message "Range: %s, Copied %s" msg cc/last-org-table-reference)
-    (kill-new cc/last-org-table-reference)))
-
-(defun cc/mouse-copy-org-table-reference-dwim ()
-  "Copy Org table reference (field or range) into kill ring via mouse.
-
-Given a point or region defined in an Org table, add to the
-`kill-ring' an Org table field or range reference.
-
-NOTE: This function is intended to be called from a mouse menu
-after `cc/copy-org-table-reference-dwim' is called which will set
-`cc/last-org-table-reference'. This is to work-around my lack of
-clarity on region and mouse menu interaction.
-
-If the region is defined over multiple columns, then a Calc
-vector matrix is returned. See Info node `(org) Formula syntax
-for Calc' for more.
-
-If the buffer *Edit Formulas* is available (usually via
-`org-table-edit-formulas'), the reference will be inserted into
-it. If the point in *Edit Formulas* is at the beginning of line,
-it will treat the reference as a left hand side (lhs) assignment.
-
-See Info node `(org) References' for more on Org table field
-reference format."
-  (interactive)
-  (if (not (org-at-table-p))
-      (error "Not in an Org table"))
-
-  (when cc/last-org-table-reference
-    (let ((msg cc/last-org-table-reference)
-          (formulas-buffer (get-buffer "*Edit Formulas*")))
-      (if formulas-buffer
-        (with-current-buffer formulas-buffer
-          (if (bolp)
-              (insert (format "%s = " msg))  ; treat reference as lhs assignment
-            (insert msg))))
-      (message "Copied %s" msg)
-      (kill-new msg))))
-
-(defun cc/org-table-range-to-reference (range)
-  "Convert RANGE object to Org table reference (field or range).
-
-If the region is defined over multiple columns, then a Calc
-vector matrix is returned. See Info node `(org) Formula syntax
-for Calc' for more.
-
-See `cc/org-table-range' for more on RANGE object."
-  (let* ((start (nth 0 range))
-         (end (nth 1 range))
-         (a (nth 0 start))
-         (b (nth 1 start))
-         (c (nth 0 end))
-         (d (nth 1 end))
-
-         (r1 (apply #'min (list a c)))
-         (c1 (apply #'min (list b d)))
-
-         (r2 (apply #'max (list a c)))
-         (c2 (apply #'max (list b d)))
-
-         (rowrange (number-sequence r1 r2))
-         (buflist (list)))
-
-
-    (cond
-     ((and (= r1 r2) (= c1 c2))
-      (format "@%d$%d" r1 c1 ))
-
-     ((or (= c1 c2) (= r1 r2))
-      (format "@%d$%d..@%d$%d" r1 c1 r2 c2))
-
-     (t
-      (mapc (lambda (r)
-              (push (format "@%d$%d..@%d$%d" r c1 r c2) buflist))
-            rowrange)
-
-      (format "vec(%s)"
-              (string-join (reverse buflist) ", "))))))
 
 (defun cc/clear-mouse-overlay ()
   "Clear secondary overlay in buffer.
@@ -820,14 +642,16 @@ See `cc/org-table-range' for more on RANGE object."
   (delete-overlay mouse-secondary-overlay))
 
 (defun cc/toggle-unicode ()
-  "Toggle Unicode symbols."
+  "Toggle Unicode and prettify symbols."
   (interactive)
-  (if prettify-symbols-mode
-      (prettify-symbols-mode -1)
-    (prettify-symbols-mode nil))
+  ;;(prettify-symbols-mode 'toggle)
   (if casual-lib-use-unicode
-      (setq-local casual-lib-use-unicode nil)
-    (setq-local casual-lib-use-unicode t)))
+      (progn
+        (setopt casual-lib-use-unicode nil)
+        (prettify-symbols-mode -1))
+    (progn
+      (setopt casual-lib-use-unicode t)
+      (prettify-symbols-mode nil))))
 
 (defun macports ()
   "Run MacPorts."

--- a/custom.el
+++ b/custom.el
@@ -129,6 +129,7 @@
    '(calendar-update-mode-line (lambda nil (diary-view-entries 1))))
  '(case-fold-search t)
  '(casual-lib-use-unicode t)
+ '(casual-timezone-datestamp-format "%a %b %-e %Y, %k:%M")
  '(column-number-mode t)
  '(company-dabbrev-downcase nil)
  '(compilation-auto-jump-to-first-error 'first-known)
@@ -261,7 +262,6 @@
  '(ibuffer-saved-filter-groups
    '(("main" ("org-agenda" (name . "Org Agenda"))
       ("posts" (directory . "org/posts"))
-      ("org" (and (directory . "org/") (mode . org-mode)))
       ("documentation"
        (or (mode . makefile-mode) (mode . Info-mode) (mode . help-mode)))
       ("casual" (directory . "Projects/elisp/casual/"))
@@ -285,7 +285,24 @@
       ("worg" (directory . "Projects/vendor/worg/"))
       ("elisp"
        (or (directory . ".config/emacs/elpa/")
-           (directory . "Emacs.app/Contents/Resources/lisp/"))))
+           (directory . "Emacs.app/Contents/Resources/lisp/")))
+      ("org" (and (directory . "org/") (mode . org-mode))))
+     ("work" ("org-agenda" (name . "Org Agenda"))
+      ("posts" (directory . "org/posts"))
+      ("documentation"
+       (or (mode . makefile-mode) (mode . Info-mode) (mode . help-mode)))
+      ("casual" (directory . "Projects/elisp/casual/"))
+      ("devnull"
+       (or (name . "*pelican-devnull*")
+           (directory . "Projects/pelican/devnull/")
+           (directory . "Projects/devnull/")))
+      ("cclisp" (directory . "emacs/cclisp/")) ("erc" (mode . erc-mode))
+      ("desktop" (directory . "Desktop/"))
+      ("downloads" (directory . "Downloads/"))
+      ("elisp"
+       (or (directory . ".config/emacs/elpa/")
+           (directory . "Emacs.app/Contents/Resources/lisp/")))
+      ("org" (and (directory . "org/") (mode . org-mode))))
      ("planning" ("Org Agenda" (name . "Org Agenda"))
       ("Documentation"
        (or (mode . Man-mode) (mode . Info-mode) (mode . help-mode)))
@@ -366,6 +383,7 @@
  '(org-clock-persist t)
  '(org-clock-sound "/System/Library/Sounds/Glass.aiff")
  '(org-confirm-babel-evaluate nil)
+ '(org-default-notes-file "~/org/notes.org")
  '(org-display-remote-inline-images 'cache)
  '(org-export-allow-bind-keywords t)
  '(org-export-backends '(ascii html icalendar latex md odt texinfo))
@@ -378,6 +396,7 @@
  '(org-html-postamble nil)
  '(org-icalendar-include-todo t)
  '(org-icalendar-use-scheduled '(event-if-todo event-if-todo-not-done todo-start))
+ '(org-imenu-depth 7)
  '(org-insert-heading-respect-content t)
  '(org-latex-classes
    '(("article" "\\documentclass[11pt]{article}"
@@ -413,6 +432,7 @@
  '(org-outline-path-complete-in-steps nil)
  '(org-plantuml-jar-path "/opt/local/share/java/plantuml/plantuml.jar")
  '(org-re-reveal-theme "moon")
+ '(org-refile-targets '((nil :maxlevel . 3) (org-agenda-files :maxlevel . 3)))
  '(org-show-notification-handler 'cc/display-notification)
  '(org-src-lang-modes
    '(("ocaml" . tuareg) ("elisp" . emacs-lisp) ("ditaa" . artist)
@@ -451,13 +471,20 @@
      ("WAITING" :background "navajo white" :foreground "dark goldenrod" :box
       (:line-width (1 . 1) :color "grey" :style "flat-button") :inverse-video t
       :height 0.8)
+     ("VERIFY" :background "navajo white" :foreground "medium slate blue" :box
+      (:line-width (1 . 1) :color "grey" :style "flat-button") :inverse-video t
+      :height 0.8)
      ("DONE" :background "gray52" :foreground "gray15" :box
       (:line-width (1 . 1) :color "grey" :style "flat-button") :inverse-video t
       :height 0.8)
      ("CANCELED" :background "DeepPink1" :foreground "gray15" :box
       (:line-width (1 . 1) :color "grey" :style "flat-button") :inverse-video t
       :height 0.8)))
+ '(org-todo-keywords
+   '((sequence "TODO(t)" "IN_PROGRESS(i)" "WAITING(w)" "VERIFY(v)" "|" "DONE(d)")
+     (sequence "|" "CANCELED(c)")))
  '(org-use-speed-commands t)
+ '(org-yank-image-save-method "~/org/images/clipped")
  '(package-archives
    '(("gnu" . "http://elpa.gnu.org/packages/")
      ("melpa" . "https://melpa.org/packages/")))
@@ -520,7 +547,7 @@
  '(trash-directory "~/.Trash")
  '(use-file-dialog nil)
  '(use-short-answers t)
- '(user-mail-address "kickingvegas@gmail.com")
+ '(user-mail-address "charles.choi@yummymelon.com")
  '(vc-follow-symlinks nil)
  '(vc-make-backup-files nil)
  '(view-read-only t)
@@ -578,7 +605,7 @@
  '(org-document-info ((((type x w32 ns pgtk) (class color) (background light)) (:foreground "midnight blue")) (((type x w32 ns pgtk) (class color) (background dark)) (:foreground "pale turquoise")) (t nil) (((type tty) (class color)) (:foreground "pale turquoise"))))
  '(org-document-info-keyword ((t (:inherit fixed-pitch))))
  '(org-document-title ((((type x ns) (class color) (background light)) (:foreground "midnight blue" :weight bold)) (((type x ns) (class color) (background dark)) (:foreground "pale turquoise" :weight bold)) (t (:weight bold)) (((type tty) (class color)) (:foreground "pale turquoise"))))
- '(org-formula ((t (:inherit fixed-pitch :foreground "Firebrick"))))
+ '(org-formula ((t (:inherit org-table :foreground "Firebrick"))))
  '(org-hide ((((type x ns) (class color) (background light)) (:foreground "white")) (((type x ns) (class color) (background dark)) (:foreground "#171717")) (((type tty) (class color)) (:foreground "#171717"))))
  '(org-meta-line ((((type x ns) (class color) (background dark)) (:inherit fixed-pitch :foreground "deep sky blue")) (((type x ns) (class color) (background light)) (:inherit fixed-pitch :foreground "grey50")) (((type tty) (class color)) (:inherit fixed-pitch :foreground "deep sky blue"))))
  '(org-scheduled ((t (:foreground "#4455ff"))))

--- a/recent-rgrep.el
+++ b/recent-rgrep.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/recent-rgrep
 ;; Keywords: tools
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -65,14 +65,14 @@
   :type '(repeat string))
 
 
-(defun recent-rgrep (query)
-  "Search QUERY in files recursively and sort by recent modification time.
+(defun recent-rgrep ()
+  "Search query in files recursively and sort by recent modification time.
 
-From the current directory, this command shall recursively search
-files for lines that match the pattern QUERY that is entered with
-the first prompt. The results are sorted in recently modified
-file order with the most recent files presented at the top of the
-buffer. By default, matching QUERY is case-insensitive.
+From the current directory, this command shall recursively search files
+for lines that match the pattern query that is entered in the first
+prompt. The results are sorted in recently modified file order with the
+most recent files presented at the top of the buffer. By default,
+matching query is case-insensitive.
 
 A second prompt to filter the extent of files to search is
 presented. By default, the extent of files searched will be all
@@ -84,16 +84,16 @@ The list of different file name glob expressions can be
 controlled via the customizable variable
 `recent-rgrep-glob-extensions'.
 
-The format of the QUERY and the glob expression must be GNU grep
+The format of the query and the glob expression must be GNU grep
 compatible.
 
-If this command is invoked with a prefix (C-u) then the search
-will be case-sensitive.
+If this command is invoked with a command prefix then the search will be
+case-sensitive.
 
 * Implementation Details
 
 This command invokes the Bash script recent-rgrep which in turn
-invokes grep to do a recursive search of QUERY.
+invokes grep to do a recursive search of query.
 
 This script is configured to only look at non-binary files. It
 will also not look into SCM directories such as .git.
@@ -101,28 +101,36 @@ will also not look into SCM directories such as .git.
 * References
 
 - Info node `(grep) Top'
-- Info node `(grep) File and Directory Selection'"
+- Info node `(grep) File and Directory Selection'
+- Info node `(emacs) Arguments'"
 
-  (interactive "sSearch regexp: ")
+  (interactive)
+  (let* ((query (if (use-region-p)
+                    (let* ((default (car
+                                     (string-split
+                                      (filter-buffer-substring (mark) (point))
+                                      "\n")))
+                           (prompt (format "Search Regex (%s): " default)))
+                      (read-string prompt nil nil default))
+                  (read-string "Search Regex: "))))
+    (let* ((file-pattern (completing-read
+                          "In files with extension (default: all): "
+                          recent-rgrep-glob-extensions))
+           (dir default-directory)
+           (commands (list)))
 
-  (let* ((file-pattern (completing-read
-                        "In files with extension (default: all): "
-                        recent-rgrep-glob-extensions))
-         (dir default-directory)
-         (commands (list)))
+      (push "recent-rgrep" commands)
+      (if current-prefix-arg
+          (push "-c" commands))
 
-    (push "recent-rgrep" commands)
-    (if current-prefix-arg
-        (push "-c" commands))
+      (if (not (string= file-pattern ""))
+          (push (format "-f '%s'" file-pattern) commands))
 
-    (if (not (string= file-pattern ""))
-        (push (format "-f '%s'" file-pattern) commands))
+      (push (format "'%s'" query) commands)
 
-    (push (format "'%s'" query) commands)
-
-    (compilation-start (string-join (reverse commands) " ") #'grep-mode)
-    (if (eq next-error-last-buffer (current-buffer))
-	(setq default-directory dir))))
+      (compilation-start (string-join (reverse commands) " ") #'grep-mode)
+      (if (eq next-error-last-buffer (current-buffer))
+	  (setq default-directory dir)))))
 
 (provide 'recent-rgrep)
 ;;; recent-rgrep.el ends here


### PR DESCRIPTION
- cc-calc-mode.el (calc-mode-map): Added C-c v binding.
- cc-context-menu.el (cc/context-menu-markup-items): Add yank-media.
- cc-dired-mode.el (cc/casual-dired-subsystem): Add cc/casual-dired-subsystem.
- cc-global-keybindings.el ("M-<kp-8>"): Add window swap states bindings.
- cc-info-mode.el: Add . binding to Info-up
- cc-org-mode.el (cc/org-table-fill-down): Add new Org table functions.
- cclisp.el (cc/prefix-symbol): Add new character functions.
- custom.el: Configure casual-timezone-datestamp-format to 24hr clock.
- Fix Ediff of Org files
- Fix cc/toggle-unicode
- Add work IBuffer group
- Org config refactor
- Moved more org customization to custom.el
- Update prog-mode-hook for imenu menubar support
- Fix for cc/blog-stage-post Pelican links
- cc-blog-utils.el (cc/blog-stage-post): Fix to replace content/nfdn with
Pelican links.
- Refactor hook for Ediff of Org and Markdown files
- cc-ediff-mode.el: Refactor hook for ediff-prepare-buffer-hook to properly diff
Org and Markdown files.
- Bind M-[, M-] to Dired marked file navigation
- Experiment with Ediff hooks
- Add C-c p binding for casual-editkit-project-tmenu
- Add macro cc/casual-suffix-to-test
- Misc Changes
  - Clean up EWW configuration
  - Change user-email-address to charles.choi@yummymelon.com
- Add VERIFY state to org-todo-keywords
- Add cc/casual-unicode-to-test
- cc-context-menu.el (cc/context-menu-journal-items): Add "Add Note".
- cc-macros.el: Make new place for macros.
- cclisp.el:
  (dictate): Improve dictate command for Emacs 30.x
- Tune org-formula face
