### PR TITLE
Context Menu Updates and Misc Changes

### DIFF
--- a/cc-compile-mode.el
+++ b/cc-compile-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-compile-mode.el --- grep mode customization      -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024  Charles Choi
+;; Copyright (C) 2024-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -28,6 +28,7 @@
 (require 'hl-line)
 (require 'casual-compile)
 (require 'goto-addr)
+(require 'anju)
 
 (add-hook 'compilation-mode-hook #'hl-line-mode)
 (add-hook 'compilation-mode-hook #'goto-address-mode)
@@ -40,6 +41,44 @@
 (keymap-set compilation-mode-map "o" #'compilation-display-error)
 (keymap-set compilation-mode-map "[" #'compilation-previous-file)
 (keymap-set compilation-mode-map "]" #'compilation-next-file)
+
+(defun cc/context-menu-compile (menu click)
+  "Context menu hook function for compile commands.
+
+- MENU: menu
+- CLICK: event
+
+This function is intended to be hooked into `context-menu-functions'."
+
+  (when (derived-mode-p 'compilation-mode)
+    (save-excursion
+      (mouse-set-point click)
+      (anju-context-menu-item-separator menu compile-separator)
+
+      (easy-menu-add-item menu nil
+                          ["Recompile"
+                           recompile
+                           :label (casual-compile--select-mode-label
+                                   "Recompile"
+                                   (casual-compile-unicode-get :refresh))
+                           :enable (not (casual-compile--compilation-running-p))
+                           :help "Recompile"])
+
+      (easy-menu-add-item menu nil
+                          ["Compile…"
+                           compile
+                           :enable
+                           (and
+                            (not (derived-mode-p 'grep-mode))
+                            (not (casual-compile--compilation-running-p)))
+                           :help "Recompile"])
+
+      (easy-menu-add-item menu nil
+                          ["Kill"
+                           kill-compilation
+                           :label (casual-compile-unicode-get :kill)
+                           :visible (casual-compile--compilation-running-p)])))
+  menu)
 
 (provide 'cc-compile-mode)
 ;;; cc-compile-mode.el ends here

--- a/cc-context-menu.el
+++ b/cc-context-menu.el
@@ -27,6 +27,7 @@
 (require 'mouse)
 (require 'org)
 (require 'org-agenda)
+(require 'reveal-in-folder)
 (require 'cclisp)
 (require 'cc-region-operations-menu)
 (require 'reveal-in-folder)
@@ -36,6 +37,26 @@
 (require 'casual-agenda)
 (require 'anju)
 
+(easy-menu-define cc/context-menu-journal-menu nil
+  "Key map for Org copy sub-menu."
+  '("Journal"
+
+    ["Journal"
+     status-report
+     :help "Go to current day journal"]
+
+    ["Agenda - All TODOs"
+     (lambda () (interactive)(org-agenda nil "n"))
+     :help "Show Org agenda with all TODO tasks"]
+
+    ["Workflow…"
+     org-capture
+     :help "Capture content via Org"]
+
+    ["Scratch"
+     scratch-buffer
+     :help "Switch to the *scratch* buffer."]))
+
 (defun cc/context-menu-journal (menu click)
   "Context menu hook function for journal commands.
 
@@ -44,26 +65,18 @@
 
 This function is intended to be hooked into `context-menu-functions'."
 
-  (save-excursion
-    (mouse-set-point click)
-    (when (and (not (anju-at-org-table-p))
-               (not (use-region-p)))
-      (anju-context-menu-item-separator menu journal-separator)
-      (easy-menu-add-item menu nil ["Journal"
-                                    status-report
-                                    :help "Go to current day journal"])
+  (when (and (not (anju-at-org-table-p))
+             (not (use-region-p)))
 
-      (easy-menu-add-item menu nil ["Agenda - All TODOs"
-                                    (lambda () (interactive)(org-agenda nil "n"))
-                                    :help "Show Org agenda with all TODO tasks"])
+    (save-excursion
+      (mouse-set-point click)
+      (anju-context-menu-item-separator menu journal-separator)
+
+      (easy-menu-add-item menu nil cc/context-menu-journal-menu)
 
       (easy-menu-add-item menu nil ["Add Note"
                                     (lambda () (interactive)(org-capture nil "j"))
-                                    :help "Add journal note"])
-
-      (easy-menu-add-item menu nil ["Scratch"
-                                    scratch-buffer
-                                    :help "Switch to the *scratch* buffer."])))
+                                    :help "Add journal note"])))
   menu)
 
 
@@ -74,22 +87,24 @@ This function is intended to be hooked into `context-menu-functions'."
 - CLICK: event
 
 This function is intended to be hooked into `context-menu-functions'."
-  (save-excursion
-    (mouse-set-point click)
-    (if (use-region-p)
+  (if (use-region-p)
+      (save-excursion
+        (mouse-set-point click)
         (easy-menu-add-item menu nil cc/region-operations-menu)))
   menu)
 
 (defun cc/context-menu-dired (menu click)
   "Context menu hook function for Dired commands.
 
+Adds Finder/File Manager to Dired.
+
 - MENU: menu
 - CLICK: event
 
 This function is intended to be hooked into `context-menu-functions'."
-  (save-excursion
-    (mouse-set-point click)
-    (when (derived-mode-p 'dired-mode)
+  (when (derived-mode-p 'dired-mode)
+    (save-excursion
+      (mouse-set-point click)
       (easy-menu-add-item menu nil
                           ["Open in File Manager"
                            reveal-in-folder-at-point
@@ -109,12 +124,11 @@ This function is intended to be hooked into `context-menu-functions'."
 - CLICK: event
 
 This function is intended to be hooked into `context-menu-functions'."
-
-  (save-excursion
-    (mouse-set-point click)
-    (when (and (not (use-region-p))
-               (not (anju-at-org-table-p))
-               (not (derived-mode-p 'dired-mode)))
+  (when (and (not (use-region-p))
+             (not (anju-at-org-table-p))
+             (not (derived-mode-p 'dired-mode)))
+    (save-excursion
+      (mouse-set-point click)
       (easy-menu-add-item menu nil
                           ["📁 Open in Finder"
                            reveal-in-folder-this-buffer
@@ -129,11 +143,9 @@ This function is intended to be hooked into `context-menu-functions'."
 - CLICK: event
 
 This function is intended to be hooked into `context-menu-functions'."
-
-  (save-excursion
-    (mouse-set-point click)
-    (when (use-region-p)
-      ;; (anju-context-menu-item-separator menu dictionary-operations-separator)
+  (when (use-region-p)
+    (save-excursion
+      (mouse-set-point click)
       (easy-menu-add-item menu nil ["Look Up"
                                     osx-dictionary-search-word-at-point
                                     :label (anju-menu-label "Look Up")
@@ -161,10 +173,9 @@ This function is intended to be hooked into `context-menu-functions'."
 
 (defun cc/context-menu-region-extension (menu click)
   "Region menu using MENU and CLICK."
-
-  (save-excursion
-    (mouse-set-point click)
-    (when (derived-mode-p 'org-mode)
+  (when (derived-mode-p 'org-mode)
+    (save-excursion
+      (mouse-set-point click)
       (easy-menu-add-item menu nil cc/context-menu-org-copy-as-menu
                           "Paste")))
   menu)
@@ -211,12 +222,15 @@ This function is intended to be hooked into `context-menu-functions'."
 
 This function is intended to be hooked into `context-menu-functions'."
 
-  (save-excursion
+  (when (derived-mode-p 'org-agenda-mode)
     (mouse-set-point click)
-    (when (derived-mode-p 'org-agenda-mode)
+    (save-excursion
       (when (casual-agenda-headlinep)
         (easy-menu-add-item menu nil ["Clock In"
                                       casual-agenda-clock-in
+                                      :label (anju-middle-truncate (org-agenda-with-point-at-orig-entry nil
+                                                                     (org-element-property :title (org-element-at-point)))
+                                                                   "Clock In")
                                       :visible (not (org-clocking-p))
                                       :help "Clock in"])
 
@@ -249,7 +263,7 @@ This function is intended to be hooked into `context-menu-functions'."
                                       org-agenda-set-tags
                                       :help "Set Tags"])
 
-        (easy-menu-add-item menu nil ["Add Note…"
+        (easy-menu-add-item menu nil ["Note…"
                                       org-agenda-add-note
                                       :help "Add note"]))
 
@@ -258,9 +272,11 @@ This function is intended to be hooked into `context-menu-functions'."
                                     :help "Goto now"])
 
       (easy-menu-add-item menu nil cc/context-menu-org-agenda-view-menu)
-      ))
-  menu)
 
+      (easy-menu-add-item menu nil ["Refresh"
+                                    org-agenda-redo-all
+                                    :help "Redo all"])))
+  menu)
 
 
 (provide 'cc-context-menu)

--- a/cc-dired-mode.el
+++ b/cc-dired-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-dired-mode.el --- Dired Customization -*- lexical-binding: t -*-
 
-;; Copyright (C) 2023-2025  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -43,7 +43,6 @@
  (lambda ()
    (setq-local mouse-1-click-follows-link 'double)))
 
-(keymap-set dired-mode-map "<mouse-2>" #'dired-mouse-find-file)
 (keymap-set dired-mode-map "M-o" #'dired-omit-mode)
 (keymap-set dired-mode-map "C-M-o" #'casual-editkit-main-tmenu)
 (keymap-set dired-mode-map "E" #'wdired-change-to-wdired-mode)
@@ -62,12 +61,23 @@
 (keymap-set dired-mode-map "." #'dired-up-directory)
 (keymap-set dired-mode-map "M-m" #'dired-rsync-transient)
 (keymap-set dired-mode-map "M-l" #'dired-other-window)
+(keymap-set dired-mode-map "C-c e" #'casual-dired-elisp-tmenu)
 
 ;; Added to be consistent with IBuffer
 (keymap-set dired-mode-map "<backtab>" #'dired-prev-subdir)
 (keymap-set dired-mode-map "TAB" #'dired-next-subdir)
 
+(defun cc/dired-mouse-toggle-mark ()
+  "Toggle mark of a Dired item via mouse."
+  (interactive)
+  (unless (use-region-p)
+    (mouse-set-point last-input-event)
+    (if (char-equal (char-after (line-beginning-position)) dired-marker-char)
+        (call-interactively #'dired-unmark)
+      (call-interactively #'dired-mark))))
+
 (keymap-set dired-mode-map "A-M-<mouse-1>" #'browse-url-of-dired-file)
+(keymap-set dired-mode-map "M-<mouse-1>" #'cc/dired-mouse-toggle-mark)
 
 (keymap-set image-dired-thumbnail-mode-map "n" #'image-dired-display-next)
 (keymap-set image-dired-thumbnail-mode-map "p" #'image-dired-display-previous)

--- a/cc-edit-text-menu.el
+++ b/cc-edit-text-menu.el
@@ -1,6 +1,6 @@
 ;;; cc-edit-text-menu.el --- Edit Text Menus -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2024  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -22,12 +22,14 @@
 ;;; Commentary:
 ;;
 
+;;; Code:
 (require 'casual-editkit)
 
 (easy-menu-define cc/transpose-menu nil
-  "Keymap for Transpose submenu"
-  '("Transpose"
+  "Keymap for Transpose submenu."
+  '("Transpose ⇄"
     :visible (not buffer-read-only)
+    :enable (not (use-region-p))
     ["Characters" transpose-chars
      :help "Interchange characters around point, moving forward one character."]
 
@@ -51,32 +53,33 @@
 expressions (sexps)."]))
 
 (easy-menu-define cc/move-text-menu nil
-  "Keymap for Move Text submenu"
+  "Keymap for Move Text submenu."
   '("Move Text"
     :visible (not buffer-read-only)
-    ["Word Forward" casual-editkit-move-word-forward
+    :enable (not (use-region-p))
+    ["Word →" casual-editkit-move-word-forward
      :help "Move word to the right of point forward one word."]
 
-    ["Word Backward" casual-editkit-move-word-backward
+    ["Word ←" casual-editkit-move-word-backward
      :help "Move word to the right of point backward one word."]
 
-    ["Sentence Forward" casual-editkit-move-sentence-forward
+    ["Sentence →" casual-editkit-move-sentence-forward
      :help "Move sentence to the right of point forward one sentence."]
 
-    ["Sentence Backward" casual-editkit-move-sentence-backward
+    ["Sentence ←" casual-editkit-move-sentence-backward
      :help "Move sentence to the right of point backward one sentence."]
 
-    ["Balanced Expression (sexp) Forward" casual-editkit-move-sexp-forward
+    ["Balanced Expression (sexp) →" casual-editkit-move-sexp-forward
      :help "Move balanced expression (sexp) to the right of point forward \
 one sexp."]
 
-    ["Balanced Expression (sexp) Backward" casual-editkit-move-sexp-backward
+    ["Balanced Expression (sexp) ←" casual-editkit-move-sexp-backward
      :help "Move balanced expression (sexp) to the right of point backward \
 one sexp."]))
 
 (easy-menu-define cc/delete-space-menu nil
-  "Keymap for Deleting Space submenu"
-  '("Delete Space"
+  "Keymap for Deleting Space submenu."
+  '("Delete"
     :visible (not buffer-read-only)
     ["Join Line" join-line
      :help "Join this line to previous and fix up \
@@ -97,8 +100,13 @@ leaving just one."]
      :help "Cleanup some blank problems in all buffer or at region."]
 
     ["Delete Trailing Whitespace" delete-trailing-whitespace
-     :help "Delete trailing whitespace between START and END."]))
+     :help "Delete trailing whitespace between START and END."]
 
+    ["Zap up to…" zap-up-to-char
+     :help "Kill up to, but not including occurrence of CHAR"]
+
+    ["Zap to…" zap-to-char
+     :help "Kill up to and including occurrence of CHAR"]))
 
 (provide 'cc-edit-text-menu)
 

--- a/cc-emacs-lisp-mode.el
+++ b/cc-emacs-lisp-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-emacs-lisp-mode.el --- Elisp Customization -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2025  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -28,14 +28,16 @@
 (require 'edebug)
 (require 'cclisp)
 (require 'calle24-edebug)
+(require 'hideshow)
 (require 'casual-elisp)
+(require 'anju)
 
 ;;; Code:
 
 ;;(add-hook 'emacs-lisp-mode-hook #'enable-paredit-mode)
 (add-hook 'emacs-lisp-mode-hook #'flycheck-mode)
 (add-hook 'emacs-lisp-mode-hook #'prettify-symbols-mode)
-
+(add-hook 'emacs-lisp-mode-hook #'hs-minor-mode)
 
 (add-hook 'emacs-lisp-mode-hook
           (lambda ()
@@ -242,6 +244,77 @@
 
 (add-hook 'edebug-eval-mode-hook #'window-tool-bar-mode)
 
+
+
+;; -------------------------------------------------------------------
+(defun cc/context-menu-elisp (menu click)
+  "Context menu hook function for Elisp commands.
+
+- MENU: menu
+- CLICK: event
+
+This function is intended to be hooked into `context-menu-functions'."
+
+  (when (derived-mode-p 'emacs-lisp-mode)
+
+    (save-excursion
+      (mouse-set-point click)
+      (anju-context-menu-item-separator menu emacs-lisp-separator)
+
+      (easy-menu-add-item
+       menu nil
+       ["Eval Defun"
+        eval-defun
+        :help "Evaluate the top level form point is in"])
+
+      (easy-menu-add-item
+       menu nil
+       ["Edebug Defun"
+        (lambda () (interactive) (eval-defun t))
+        :help "Evaluate the top level form point is in, stepping through with Edebug"])
+
+      (easy-menu-add-item
+       menu nil
+       ["Toggle Hiding"
+        hs-toggle-hiding
+        :enable hs-minor-mode
+        :label (if (hs-already-hidden-p) "Show Sexp" "Hide Sexp")
+        :help "Toggle hiding"])
+      ))
+  menu)
+
+
+;; -------------------------------------------------------------------
+;; Fix vector indentation.
+;; This code taken from
+;; https://github.com/magit/emacsql/blob/2fe6d4562b32a170a750d5e80514fbb6b6694803/emacsql.el#L357-L379
+;; per guidance from J. Bernoulli to fix vector formatting.
+
+(defun emacsql--inside-vector-p ()
+  "Return non-nil if point is inside a vector expression."
+  (let ((start (point)))
+    (save-excursion
+      (beginning-of-defun)
+      (let ((containing-sexp (elt (parse-partial-sexp (point) start) 1)))
+        (and containing-sexp
+             (progn (goto-char containing-sexp)
+                    (looking-at "\\[")))))))
+
+(defun emacsql--calculate-vector-indent (fn &optional parse-start)
+  "Don't indent vectors in `emacs-lisp-mode' like lists."
+  (if (save-excursion (beginning-of-line) (emacsql--inside-vector-p))
+      (let ((lisp-indent-offset 1))
+        (funcall fn parse-start))
+    (funcall fn parse-start)))
+
+(defun emacsql-fix-vector-indentation ()
+  "When called, advise `calculate-lisp-indent' to stop indenting vectors.
+Once activated, vector contents no longer indent like lists."
+  (interactive)
+  (advice-add 'calculate-lisp-indent :around
+              #'emacsql--calculate-vector-indent))
+
+(emacsql-fix-vector-indentation)
 
 (provide 'cc-emacs-lisp-mode)
 ;;; cc-emacs-lisp-mode.el ends here

--- a/cc-ibuffer-mode.el
+++ b/cc-ibuffer-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-ibuffer-mode.el --- ibuffer configuration     -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024  Charles Choi
+;; Copyright (C) 2024-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -30,6 +30,7 @@
 (require 'mouse)
 (require 'casual-ibuffer)
 (require 'avy)
+;; (require 'anju)
 
 (add-hook 'ibuffer-mode-hook #'hl-line-mode)
 (add-hook 'ibuffer-mode-hook #'ibuffer-auto-mode)
@@ -60,6 +61,24 @@
 (keymap-set ibuffer-mode-map "]" #'ibuffer-forward-filter-group)
 (keymap-set ibuffer-mode-map "$" #'ibuffer-toggle-filter-group)
 (keymap-set ibuffer-mode-map "J" #'ibuffer-jump-to-filter-group)
+
+;; (defun cc/context-menu-ibuffer (menu click)
+;;   "Context menu hook function for Ibuffer commands.
+
+;; - MENU: menu
+;; - CLICK: event
+
+;; This function is intended to be hooked into `context-menu-functions'."
+
+;;   (mouse-set-point click)
+
+;;   (save-excursion
+;;     (when (derived-mode-p 'ibuffer-mode)
+;;       (easy-menu-add-item menu nil ["Switch to filter group…"
+;;                                     casual-ibuffer-switch-to-saved-filter-groups
+;;                                     :help "Switch to Ibuffer filter group"])
+;;       ))
+;;   menu)
 
 (provide 'cc-ibuffer-mode)
 ;;; cc-ibuffer-mode.el ends here

--- a/cc-make-mode.el
+++ b/cc-make-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-make-mode.el --- makefile-mode configuration   -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024-2025  Charles Choi
+;; Copyright (C) 2024-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -30,12 +30,8 @@
 (keymap-set makefile-mode-map "<f9>" #'compile)
 (keymap-set makefile-mode-map "C-6" #'imenu)
 
-;;(add-hook 'makefile-mode-hook #'makefile-gmake-mode)
-
-(add-hook 'makefile-mode-hook #'imenu-add-menubar-index)
 (add-hook 'makefile-mode-hook
           (lambda ()
-            (setq-local imenu-auto-rescan t)
             (setq-local imenu-sort-function #'imenu--sort-by-name)))
 
 (keymap-set makefile-mode-map "M-m" #'casual-make-tmenu)

--- a/cc-markdown-mode.el
+++ b/cc-markdown-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-markdown-mode.el --- Markdown customizations -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2024  Charles Choi
+;; Copyright (C) 2023-2026 Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -52,8 +52,6 @@
 ;; (define-key markdown-mode-map [f13] 'markdown-preview)
 
 (add-hook 'markdown-mode-hook #'cc/save-hook-delete-trailing-whitespace)
-(add-hook 'markdown-mode-hook #'imenu-add-menubar-index)
-(add-hook 'markdown-mode-hook (lambda () (setq-local imenu-auto-rescan t)))
 
 (transient-define-prefix cc/markdown-mode-tmenu ()
   ["Markdown"

--- a/cc-menu-reconfig.el
+++ b/cc-menu-reconfig.el
@@ -1,6 +1,6 @@
 ;;; cc-menu-reconfig.el --- Menu reconfiguration -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2025  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -64,24 +64,11 @@ WINDOW-2."]
                        transpose-frame
                        :visible (> (count-windows) 1)
                        :help "Transpose windows arrangement at FRAME."]
-                      "New Window Below"))
+                      "New Window Below")
 
+  (define-key global-map [menu-bar file make-frame-on-display] nil t)
+  (define-key global-map [menu-bar file make-frame-on-monitor] nil t))
 
-
-;; -------------------------------------------------------------------
-;; Reconfigure Text Mode Menu
-
-(defun cc/reconfigure-text-mode-menu ()
-  "Reconfigure Text mode menu."
-  (easy-menu-remove-item text-mode-menu nil "Center Line")
-  (easy-menu-remove-item text-mode-menu nil "Center Region")
-  (easy-menu-remove-item text-mode-menu nil "Center Paragraph")
-  (easy-menu-remove-item text-mode-menu nil "Paragraph Indent")
-  (easy-menu-remove-item text-mode-menu nil "---")
-
-  (easy-menu-add-item text-mode-menu nil anju-transform-text-menu "Auto Fill")
-  (easy-menu-add-item text-mode-menu nil anju-style-menu "Auto Fill")
-  (easy-menu-add-item text-mode-menu nil cc/region-operations-menu "Auto Fill"))
 
 
 ;; -------------------------------------------------------------------
@@ -114,28 +101,31 @@ for REGEXP."
                        :visible (not buffer-read-only)]
                       "Fill")
 
-  (easy-menu-add-item global-map '(menu-bar edit)
-                      ["Colors"
-                       ns-popup-color-panel
-                       :help "Show macOS Color Picker."
-                       :visible (eq window-system 'ns)])
+  (when (eq window-system 'ns)
+    (easy-menu-add-item global-map '(menu-bar edit)
+                        ["Colors"
+                         ns-popup-color-panel
+                         :help "Show macOS Color Picker."
+                         :visible (eq window-system 'ns)])
 
-  (easy-menu-add-item global-map '(menu-bar edit)
-                      ["Emoji & Symbols"
-                       ns-do-show-character-palette
-                       :help "Show macOS Character Palette."
-                       :visible (eq window-system 'ns)]))
+    (easy-menu-add-item global-map '(menu-bar edit)
+                        ["Emoji & Symbols"
+                         ns-do-show-character-palette
+                         :help "Show macOS Character Palette."
+                         :visible (eq window-system 'ns)]))
+
+  (define-key global-map [menu-bar edit execute-extended-command] nil t))
 
 
 ;; -------------------------------------------------------------------
 ;;; Reconfigure Tools Menu
 (defun cc/reconfigure-tools-menu ()
   "Reconfigure Tools menu."
-  (easy-menu-add-item global-map '(menu-bar tools)
-                      ["Agenda - All TODOs"
-                       (lambda () (interactive)(org-agenda nil "n"))
-                       :help "Show Org agenda with all TODO tasks."]
-                      "Shell Commands")
+  ;; (easy-menu-add-item global-map '(menu-bar tools)
+  ;;                     ["Agenda - All TODOs"
+  ;;                      (lambda () (interactive)(org-agenda nil "n"))
+  ;;                      :help "Show Org agenda with all TODO tasks."]
+  ;;                     "Shell Commands")
 
   (easy-menu-add-item global-map '(menu-bar tools)
                       ["Set Input Method - Korean"
@@ -144,17 +134,17 @@ for REGEXP."
                        :help "Set input method to Korean"]
                       "Shell Commands")
 
-  (easy-menu-add-item global-map '(menu-bar tools)
-                      ["Open in Finder"
-                       reveal-in-folder-this-buffer
-                       :visible (or (buffer-file-name) (derived-mode-p 'dired-mode))
-                       :help "Reveal the current buffer in folder."]
-                      "Shell Commands")
+  ;; (easy-menu-add-item global-map '(menu-bar tools)
+  ;;                     ["Open in Finder"
+  ;;                      reveal-in-folder-this-buffer
+  ;;                      :visible (or (buffer-file-name) (derived-mode-p 'dired-mode))
+  ;;                      :help "Reveal the current buffer in folder."]
+  ;;                     "Shell Commands")
 
-  (keymap-set-after (lookup-key global-map [menu-bar tools])
-    "<separator-org>"
-    '(menu-item "--")
-    'Agenda\ -\ All\ TODOs)
+  ;; (keymap-set-after (lookup-key global-map [menu-bar tools])
+  ;;   "<separator-org>"
+  ;;   '(menu-item "--")
+  ;;   'Agenda\ -\ All\ TODOs)
 
   ;; (easy-menu-add-item global-map '(menu-bar tools)
   ;;                     ["Find File…"

--- a/cc-org-agenda.el
+++ b/cc-org-agenda.el
@@ -1,6 +1,6 @@
 ;;; cc-org-agenda.el --- Org Agenda Configuration    -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024  Charles Choi
+;; Copyright (C) 2024, 2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; Keywords: tools
@@ -29,14 +29,6 @@
 (keymap-set org-agenda-mode-map "C-o" #'casual-agenda-tmenu)
 (keymap-set org-agenda-mode-map "M-j" #'org-agenda-clock-goto)
 (keymap-set org-agenda-mode-map "J" #'bookmark-jump)
-
-;; (use-package casual-agenda
-;;   :ensure nil
-;;   :bind (:map
-;;          org-agenda-mode-map
-;;          ("C-o" . casual-agenda-tmenu)
-;;          ("M-j" . org-agenda-clock-goto) ; optional
-;;          ("J" . bookmark-jump))) ; optional
 
 (provide 'cc-org-agenda)
 ;;; cc-org-agenda.el ends here

--- a/cc-org-mode.el
+++ b/cc-org-mode.el
@@ -1,6 +1,6 @@
 ;;; cc-org-mode.el --- Org configuration -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2025  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -85,8 +85,6 @@ which is done with `org-ctrl-c-ctrl-c'."
 (add-hook 'org-mode-hook (lambda ()
                            (cc/reconfig-org-smart-quotes-lang "en")))
 
-(add-hook 'org-mode-hook #'imenu-add-menubar-index)
-(add-hook 'org-mode-hook (lambda () (setq-local imenu-auto-rescan t)))
 (add-hook
  'org-mode-hook
  (lambda ()
@@ -146,14 +144,18 @@ SUFFIX - string appended to prefix
                              "warningbox"
                              "blindtext")))
        (dolist (e base-list)
-         (push (cons (concat "#+begin_" e)
-                     (cc/--prettify-components ?⎧ e)) prettify-symbols-alist)
-         (push (cons (concat "#+BEGIN_" (upcase e))
-                     (cc/--prettify-components ?⎧ e)) prettify-symbols-alist)
-         (push (cons (concat "#+end_" e)
-                     (cc/--prettify-components ?⎩ e)) prettify-symbols-alist)
-         (push (cons (concat "#+END_" (upcase e))
-                     (cc/--prettify-components ?⎩ e)) prettify-symbols-alist)))
+         (push
+          (cons (concat "#+begin_" e) (cc/--prettify-components ?⎧ e))
+          prettify-symbols-alist)
+         (push
+          (cons (concat "#+BEGIN_" (upcase e)) (cc/--prettify-components ?⎧ e))
+          prettify-symbols-alist)
+         (push
+          (cons (concat "#+end_" e) (cc/--prettify-components ?⎩ e))
+          prettify-symbols-alist)
+         (push
+          (cons (concat "#+END_" (upcase e)) (cc/--prettify-components ?⎩ e))
+          prettify-symbols-alist)))
      (prettify-symbols-mode))))
 
 (defun cc/org-backward-paragraph ()
@@ -267,9 +269,6 @@ SUFFIX - string appended to prefix
       (org-capture nil "J")
     (org-capture nil "j")))
 
-(defalias 'cc/insert-org-keyword
-  (kmacro "C-a # + M-x c o m p l e t e - s y m b o l <return>"))
-
 (require 'cc-org-capture)
 
 (defun cc/disable-flycheck-in-org-src-block ()
@@ -284,6 +283,37 @@ SUFFIX - string appended to prefix
 (keymap-set org-mode-map "M-m" #'casual-org-tmenu)
 (keymap-set org-table-fedit-map "M-m" #'casual-org-table-fedit-tmenu)
 (keymap-set org-table-fedit-map "<f1>" #'casual-org-table-fedit-tmenu)
+
+
+;; -------------------------------------------------------------------
+(defun cc/--days-until (target &optional template)
+  "Formatted string of days until TARGET.
+
+- TARGET: date string that conforms to `parse-time-string'.
+- TEMPLATE : format string that includes ‘%d’ specifier.
+
+If TEMPLATE is nil, then a predefined format string will be
+used."
+  (let* ((template (if template
+                       template
+                     (concat "%d days until " target)))
+         (days (org-time-stamp-to-now target))
+         (msg (format template days)))
+    msg))
+
+(defun cc/days-until (arg)
+  "Prompt user for date and show days until in the mini-buffer.
+
+Use `org-read-date' to compute days until to display in the mini-buffer.
+
+If prefix ARG is non-nil, then the computed result is stored in the
+ `kill-ring'."
+  (interactive "P")
+  (let* ((target (org-read-date))
+         (msg (cc/--days-until target)))
+    (if arg
+        (kill-new msg))
+    (message msg)))
 
 ;; ox-gfm init is so broken. need to load it manually.
 (eval-after-load "org"

--- a/cc-prog-mode.el
+++ b/cc-prog-mode.el
@@ -50,16 +50,15 @@
 (add-hook 'prog-mode-hook #'flyspell-prog-mode)
 (add-hook 'prog-mode-hook #'goto-address-prog-mode)
 (add-hook 'prog-mode-hook #'cc/save-hook-delete-trailing-whitespace)
-(add-hook 'prog-mode-hook
-          (lambda nil
-            (condition-case err (imenu-add-menubar-index)
-              (imenu-unavailable
-               (let ((inhibit-message t))
-                 (message "Warning: %s" (error-message-string err)))))))
+;; (add-hook 'prog-mode-hook
+;;           (lambda nil
+;;             (condition-case err (imenu-add-menubar-index)
+;;               (imenu-unavailable
+;;                (let ((inhibit-message t))
+;;                  (message "Warning: %s" (error-message-string err)))))))
 
 (add-hook 'prog-mode-hook
           (lambda ()
-            (setq-local imenu-auto-rescan t)
             (setq-local imenu-sort-function #'imenu--sort-by-name)))
 
 (define-key prog-mode-map [remap indent-for-tab-command]

--- a/ccinit.el
+++ b/ccinit.el
@@ -1,6 +1,6 @@
 ;;; ccinit.el --- CC Emacs Init File -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2025  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -50,6 +50,19 @@
 (set-language-environment "UTF-8")
 (set-default-coding-systems 'utf-8-unix)
 (recentf-mode 1)
+
+
+;; Config stolen from
+;; https://emacsredux.com/blog/2026/04/07/stealing-from-the-best-emacs-configs/
+
+(setq-default bidi-display-reordering 'left-to-right
+              bidi-paragraph-direction 'left-to-right)
+(setq bidi-inhibit-bpa t)
+
+(setq redisplay-skip-fontification-on-input t)
+
+;; (setq read-process-output-max (* 4 1024 1024)) ; 4MB
+
 
 ;; (when (eq window-system 'x)
 ;;   (setq x-meta-keysym 'super
@@ -183,11 +196,25 @@
 ;;   (mac-toggle-tab-bar))
 
 (defun cc/tty-mouse ()
+  "Configure mouse for TTY."
   (interactive)
   (unless (display-graphic-p)
     (xterm-mouse-mode 1)
     (global-set-key (kbd "<mouse-4>") 'scroll-down-line)
     (global-set-key (kbd "<mouse-5>") 'scroll-up-line)))
+
+(defun cc/days-until-voting (arg)
+  "Days until U.S. elections in 2026 and 2028.
+
+If prefix ARG is non-nil, then the computed result is stored in the
+ `kill-ring'."
+  (interactive "P")
+  (let* ((midterms (cc/--days-until "2026-11-03" "%d days until 2026 midterms"))
+         (election (cc/--days-until "2028-11-07" "%d days until 2028 presidential election"))
+         (msg (format "%s, %s" midterms election)))
+    (if arg
+        (kill-new msg))
+    (message msg)))
 
 (defun cc/workplace ()
   "Initialize workplace."
@@ -197,7 +224,10 @@
   (org-agenda nil "n")
   (casual-agenda-goto-now)
   (eshell t)
-  (switch-to-buffer (format-time-string "%Y_%m_%d.org")))
+  (switch-to-buffer (format-time-string "%Y_%m_%d.org"))
+  ;; (cc/days-until-voting)
+  )
+
 
 ;; (password-store-menu-enable)
 

--- a/cclisp.el
+++ b/cclisp.el
@@ -1,6 +1,6 @@
 ;;; cclisp.el --- Utility Functions -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2025  Charles Choi
+;; Copyright (C) 2023-2026  Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 
@@ -1008,6 +1008,13 @@ This command is tuned for macOS using a single display."
     (process-lines "open" "-a" "Music.app"))
    (t
     (message "Unsupported"))))
+
+(defun cc/cleanup-prog ()
+  "Cleanup code buffer."
+    (indent-region (point-min) (point-max))
+    (whitespace-cleanup)
+    (save-buffer))
+
 
 (provide 'cclisp)
 ;;; cclisp.el ends here

--- a/custom.el
+++ b/custom.el
@@ -13,6 +13,7 @@
  '(anju-reconfigure-main-menu-hook
    '(anju-main-menu--reconfigure-bookmarks anju-main-menu--reconfigure-text-mode
                                            anju-main-menu--reconfigure-help
+                                           anju-main-menu--reconfigure-imenu
                                            cc/reconfigure-file-menu
                                            cc/reconfigure-edit-menu
                                            cc/reconfigure-tools-menu))
@@ -142,17 +143,18 @@
  '(compilation-auto-jump-to-first-error 'first-known)
  '(compilation-scroll-output t)
  '(context-menu-functions
-   '(anju-context-menu-dired cc/context-menu-org-agenda anju-context-menu-org-mode
-                             cc/context-menu-journal anju-context-menu-buffers
-                             anju-context-menu-region cc/context-menu-dictionary
-                             cc/context-menu-region anju-context-menu-narrow
-                             anju-context-menu-open-in cc/context-menu-open-in
-                             anju-context-menu-vc anju-context-menu-markup
-                             anju-context-menu-wordcount context-menu-undo
-                             context-menu-region
-                             anju-context-menu-region-extension
-                             cc/context-menu-region-extension
-                             anju-context-menu-window))
+   '(cc/context-menu-elisp cc/context-menu-compile anju-context-menu-dired
+                           cc/context-menu-dired cc/context-menu-org-agenda
+                           anju-context-menu-org-mode cc/context-menu-journal
+                           anju-context-menu-buffers anju-context-menu-region
+                           cc/context-menu-dictionary cc/context-menu-region
+                           anju-context-menu-narrow anju-context-menu-open-in
+                           cc/context-menu-open-in anju-context-menu-vc
+                           anju-context-menu-markup anju-context-menu-wordcount
+                           context-menu-undo context-menu-region
+                           anju-context-menu-region-extension
+                           cc/context-menu-region-extension
+                           anju-context-menu-window))
  '(current-language-environment "English")
  '(cursor-type 'bar)
  '(custom-safe-themes
@@ -172,7 +174,7 @@
  '(dired-guess-shell-alist-user '(("" "open")))
  '(dired-listing-switches
    "-lh --group-directories-first --time-style=long-iso -g --no-group")
- '(dired-mouse-drag-files t)
+ '(dired-mouse-drag-files 'move)
  '(dired-movement-style 'cycle)
  '(dired-use-ls-dired t)
  '(dired-vc-rename-file t)
@@ -263,6 +265,7 @@
  '(gnuplot-info-display 'frame)
  '(graphviz-dot-indent-width 4)
  '(graphviz-dot-preview-extension "svg")
+ '(help-window-select t)
  '(hi-lock-auto-select-face t)
  '(highlight-nonselected-windows nil)
  '(hippie-expand-try-functions-list
@@ -371,6 +374,7 @@
  '(inhibit-startup-screen t)
  '(isearch-allow-scroll 'unlimited)
  '(isearch-lazy-count t)
+ '(kill-do-not-save-duplicates t)
  '(kill-whole-line t)
  '(lazy-count-prefix-format nil)
  '(lazy-count-suffix-format " [%s of %s]")
@@ -566,7 +570,7 @@
  '(tramp-terminal-type "tramp")
  '(transient-align-variable-pitch t)
  '(trash-directory "~/.Trash")
- '(use-file-dialog t)
+ '(use-file-dialog nil)
  '(use-short-answers t)
  '(user-mail-address "kickingvegas@gmail.com")
  '(vc-follow-symlinks nil)


### PR DESCRIPTION
* Cleanup personal context-menus
* Misc code cleanup
* cc-context-menu.el (cc/context-menu-org-agenda): Fix bug where mouse event is
processed before save-excursion. This breaks processing of describe-mode.
* Remove imenu-add-menubar-index and use Anju instead
* cc-edit-text-menu.el (cc/transpose-menu): Tune labels and test to not use in
region.
* cc-ibuffer-mode.el: stub out cc/context-menu-ibuffer.
* cc-menu-reconfig.el: tune main menu reconfiguration.
* Fix checkdoc bugs
* Add cc/context-menu-compile
* Add imenu to main menu
* Clean up logic of context menus
* Add cc/context-menu-elisp
* Update transpose symbol
* Add cc/dired-mouse-toggle-mark
* Add Batsov improvements
* Add support for days until
  - Add cc/days-until-voting
* ccinit.el (cc/tty-mouse): Add doc string for cc/tty-mouse
* Add workflow menu item
* Add binding to casual-dired-elisp-tmenu in dired-mode-map
* Remove cc/reconfigure-text-mode-menu
* Augment Elisp vector indentation.
* Add cc/cleanup-prog.
* Set use-file-dialog to nil.
